### PR TITLE
PR-1: Test-mode bootstrap (G1)

### DIFF
--- a/cmd/run_test_server.go
+++ b/cmd/run_test_server.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -59,7 +60,24 @@ func RunTestServer(dbPath string, port int) error {
 
 	app.UseHandler(router)
 
-	log.INFO.Printf("test-mode: starting on :%d (sqlite=%s)", port, dbPath)
-	graceful.Run(fmt.Sprintf(":%d", port), 5*time.Second, app)
+	addr := fmt.Sprintf(":%d", port)
+
+	// Pre-bind the listener so we can surface a clean error if the port is
+	// in use. graceful.Run otherwise log.Fatals from a goroutine, which is
+	// hard to read.
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("test-mode: cannot bind %s: %w (try --test-port=<n>)", addr, err)
+	}
+
+	log.INFO.Printf("test-mode: listening on %s (sqlite=%s)", addr, dbPath)
+
+	srv := &graceful.Server{
+		Timeout: 5 * time.Second,
+		Server:  &http.Server{Addr: addr, Handler: app},
+	}
+	if err := srv.Serve(ln); err != nil {
+		return fmt.Errorf("test-mode: server stopped: %w", err)
+	}
 	return nil
 }

--- a/cmd/run_test_server.go
+++ b/cmd/run_test_server.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/RichardKnop/go-oauth2-server/database"
+	"github.com/RichardKnop/go-oauth2-server/log"
+	"github.com/RichardKnop/go-oauth2-server/models"
+	"github.com/RichardKnop/go-oauth2-server/services"
+	"github.com/RichardKnop/go-oauth2-server/testmode"
+	"github.com/RichardKnop/go-oauth2-server/util/migrations"
+	"github.com/gorilla/mux"
+	"github.com/phyber/negroni-gzip/gzip"
+	"github.com/urfave/negroni"
+	"gopkg.in/tylerb/graceful.v1"
+)
+
+// RunTestServer boots the server in headless test-provider mode: no remote
+// config, embedded SQLite, control-plane routes mounted under /test.
+func RunTestServer(dbPath string, port int) error {
+	cnf := testmode.NewConfig(dbPath)
+
+	db, err := database.NewDatabase(cnf)
+	if err != nil {
+		return fmt.Errorf("opening sqlite database at %q: %w", dbPath, err)
+	}
+	defer db.Close()
+
+	if err := migrations.Bootstrap(db); err != nil {
+		return fmt.Errorf("bootstrap migrations: %w", err)
+	}
+	if err := models.MigrateAll(db); err != nil {
+		return fmt.Errorf("running migrations: %w", err)
+	}
+	if err := testmode.Seed(db); err != nil {
+		return fmt.Errorf("seeding default roles/scopes: %w", err)
+	}
+
+	if err := services.Init(cnf, db); err != nil {
+		return fmt.Errorf("initialising services: %w", err)
+	}
+	defer services.Close()
+
+	app := negroni.New()
+	app.Use(negroni.NewRecovery())
+	app.Use(negroni.NewLogger())
+	app.Use(gzip.Gzip(gzip.DefaultCompression))
+	app.Use(negroni.NewStatic(http.Dir("public")))
+
+	router := mux.NewRouter()
+	services.HealthService.RegisterRoutes(router, "/v1")
+	services.OauthService.RegisterRoutes(router, "/v1/oauth")
+	services.WebService.RegisterRoutes(router, "/web")
+
+	testService := testmode.NewService(cnf, db, services.OauthService)
+	testService.RegisterRoutes(router, "/test")
+
+	app.UseHandler(router)
+
+	log.INFO.Printf("test-mode: starting on :%d (sqlite=%s)", port, dbPath)
+	graceful.Run(fmt.Sprintf(":%d", port), 5*time.Second, app)
+	return nil
+}

--- a/database/database.go
+++ b/database/database.go
@@ -9,6 +9,7 @@ import (
 
 	// Drivers
 	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func init() {
@@ -47,6 +48,23 @@ func NewDatabase(cnf *config.Config) (*gorm.DB, error) {
 		// Database logging
 		db.LogMode(cnf.IsDevelopment)
 
+		return db, nil
+	}
+
+	// SQLite
+	if cnf.Database.Type == "sqlite3" {
+		// cnf.Database.DatabaseName carries the file path or ":memory:"
+		db, err := gorm.Open("sqlite3", cnf.Database.DatabaseName)
+		if err != nil {
+			return db, err
+		}
+
+		// Enforce foreign keys in SQLite (off by default)
+		if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+			return db, err
+		}
+
+		db.LogMode(cnf.IsDevelopment)
 		return db, nil
 	}
 

--- a/go-oauth2-server.go
+++ b/go-oauth2-server.go
@@ -11,6 +11,9 @@ import (
 var (
 	cliApp        *cli.App
 	configBackend string
+	testMode      bool
+	testDBPath    string
+	testPort      int
 )
 
 func init() {
@@ -31,6 +34,26 @@ func init() {
 }
 
 func main() {
+	runserverFlags := []cli.Flag{
+		cli.BoolFlag{
+			Name:        "test-mode",
+			Usage:       "run as a controllable test provider: use embedded SQLite, skip remote config, expose /test/* control plane",
+			Destination: &testMode,
+		},
+		cli.StringFlag{
+			Name:        "test-db-path",
+			Usage:       "path to SQLite database file (default: in-memory). Only used with --test-mode",
+			Value:       ":memory:",
+			Destination: &testDBPath,
+		},
+		cli.IntFlag{
+			Name:        "test-port",
+			Usage:       "port to bind in test mode",
+			Value:       8080,
+			Destination: &testPort,
+		},
+	}
+
 	// Set the CLI app commands
 	cliApp.Commands = []cli.Command{
 		{
@@ -50,7 +73,11 @@ func main() {
 		{
 			Name:  "runserver",
 			Usage: "run web server",
+			Flags: runserverFlags,
 			Action: func(c *cli.Context) error {
+				if testMode {
+					return cmd.RunTestServer(testDBPath, testPort)
+				}
 				return cmd.RunServer(configBackend)
 			},
 		},

--- a/models/migrations.go
+++ b/models/migrations.go
@@ -48,6 +48,14 @@ func migrate0001(db *gorm.DB, name string) error {
 	if err := db.CreateTable(new(OauthAuthorizationCode)).Error; err != nil {
 		return fmt.Errorf("Error creating oauth_authorization_codes table: %s", err)
 	}
+
+	// SQLite does not support adding foreign keys via ALTER TABLE. FK
+	// constraints are not enforced in test-mode SQLite; the tables retain
+	// the same column shape so application logic behaves identically.
+	if db.Dialect().GetName() == "sqlite3" {
+		return nil
+	}
+
 	err := db.Model(new(OauthUser)).AddForeignKey(
 		"role_id", "oauth_roles(id)",
 		"RESTRICT", "RESTRICT",

--- a/testmode/config.go
+++ b/testmode/config.go
@@ -1,0 +1,31 @@
+package testmode
+
+import (
+	"github.com/RichardKnop/go-oauth2-server/config"
+)
+
+// NewConfig returns an in-memory configuration suitable for the headless
+// test provider. It bypasses the etcd/consul backend entirely so the server
+// can boot without external dependencies.
+//
+// dbPath is the SQLite database path; pass ":memory:" for an ephemeral DB.
+func NewConfig(dbPath string) *config.Config {
+	return &config.Config{
+		Database: config.DatabaseConfig{
+			Type:         "sqlite3",
+			DatabaseName: dbPath,
+		},
+		Oauth: config.OauthConfig{
+			AccessTokenLifetime:  3600,
+			RefreshTokenLifetime: 1209600,
+			AuthCodeLifetime:     3600,
+		},
+		Session: config.SessionConfig{
+			Secret:   "test_secret",
+			Path:     "/",
+			MaxAge:   86400,
+			HTTPOnly: true,
+		},
+		IsDevelopment: true,
+	}
+}

--- a/testmode/handlers.go
+++ b/testmode/handlers.go
@@ -1,0 +1,102 @@
+package testmode
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/RichardKnop/go-oauth2-server/log"
+	"github.com/RichardKnop/go-oauth2-server/oauth/roles"
+	"github.com/RichardKnop/go-oauth2-server/util/response"
+)
+
+type createClientRequest struct {
+	Key         string `json:"key"`
+	Secret      string `json:"secret"`
+	RedirectURI string `json:"redirect_uri"`
+
+	// Accepted but not yet enforced; reserved for PR-3 / PR-8.
+	Scope                   string `json:"scope,omitempty"`
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`
+}
+
+type clientResponse struct {
+	ID          string `json:"id"`
+	Key         string `json:"key"`
+	RedirectURI string `json:"redirect_uri,omitempty"`
+}
+
+func (s *Service) createClient(w http.ResponseWriter, r *http.Request) {
+	var req createClientRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		response.Error(w, "invalid JSON body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Key == "" {
+		response.Error(w, "key is required", http.StatusBadRequest)
+		return
+	}
+	if req.Scope != "" || req.TokenEndpointAuthMethod != "" {
+		log.INFO.Printf("testmode: /test/clients received scope=%q token_endpoint_auth_method=%q "+
+			"(accepted but not yet enforced; see PR-3, PR-8)",
+			req.Scope, req.TokenEndpointAuthMethod)
+	}
+
+	client, err := s.oauthService.CreateClient(req.Key, req.Secret, req.RedirectURI)
+	if err != nil {
+		response.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	response.WriteJSON(w, clientResponse{
+		ID:          client.ID,
+		Key:         client.Key,
+		RedirectURI: client.RedirectURI.String,
+	}, http.StatusCreated)
+}
+
+type createUserRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Role     string `json:"role"`
+}
+
+type userResponse struct {
+	ID       string `json:"id"`
+	Username string `json:"username"`
+	Role     string `json:"role"`
+}
+
+func (s *Service) createUser(w http.ResponseWriter, r *http.Request) {
+	var req createUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		response.Error(w, "invalid JSON body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Username == "" {
+		response.Error(w, "username is required", http.StatusBadRequest)
+		return
+	}
+	role := req.Role
+	if role == "" {
+		role = roles.User
+	}
+
+	user, err := s.oauthService.CreateUser(role, req.Username, req.Password)
+	if err != nil {
+		response.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	response.WriteJSON(w, userResponse{
+		ID:       user.ID,
+		Username: user.Username,
+		Role:     user.RoleID.String,
+	}, http.StatusCreated)
+}
+
+func (s *Service) health(w http.ResponseWriter, r *http.Request) {
+	response.WriteJSON(w, map[string]string{
+		"status": "ok",
+		"mode":   "test",
+	}, http.StatusOK)
+}

--- a/testmode/integration_test.go
+++ b/testmode/integration_test.go
@@ -1,0 +1,178 @@
+package testmode_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/database"
+	"github.com/RichardKnop/go-oauth2-server/models"
+	"github.com/RichardKnop/go-oauth2-server/oauth"
+	"github.com/RichardKnop/go-oauth2-server/testmode"
+	"github.com/RichardKnop/go-oauth2-server/util/migrations"
+	"github.com/gorilla/mux"
+)
+
+func newTestApp(t *testing.T, withTestMode bool) *httptest.Server {
+	t.Helper()
+
+	cnf := testmode.NewConfig(":memory:")
+	db, err := database.NewDatabase(cnf)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	if err := migrations.Bootstrap(db); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	if err := models.MigrateAll(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if err := testmode.Seed(db); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	router := mux.NewRouter()
+	oauthService := oauth.NewService(cnf, db)
+	oauthService.RegisterRoutes(router, "/v1/oauth")
+
+	if withTestMode {
+		ts := testmode.NewService(cnf, db, oauthService)
+		ts.RegisterRoutes(router, "/test")
+	}
+
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestTestModeBootstrap(t *testing.T) {
+	srv := newTestApp(t, true)
+
+	t.Run("health", func(t *testing.T) {
+		resp := mustGet(t, srv.URL+"/test/health")
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+		var body map[string]string
+		json.NewDecoder(resp.Body).Decode(&body)
+		resp.Body.Close()
+		if body["status"] != "ok" || body["mode"] != "test" {
+			t.Fatalf("unexpected health body: %v", body)
+		}
+	})
+
+	t.Run("register client and obtain client_credentials token", func(t *testing.T) {
+		// Register client.
+		body := mustPostJSON(t, srv.URL+"/test/clients", map[string]string{
+			"key":          "acme",
+			"secret":       "s3cret",
+			"redirect_uri": "https://example.com/cb",
+		})
+		var clientResp struct {
+			ID, Key, RedirectURI string `json:""`
+		}
+		if err := json.Unmarshal(body, &clientResp); err != nil {
+			t.Fatalf("decode client: %v body=%s", err, body)
+		}
+		if clientResp.Key != "acme" {
+			t.Fatalf("expected key=acme got %q", clientResp.Key)
+		}
+
+		// Exchange via client_credentials.
+		form := url.Values{}
+		form.Set("grant_type", "client_credentials")
+		form.Set("scope", "read")
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth("acme", "s3cret")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("token request: %v", err)
+		}
+		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 got %d body=%s", resp.StatusCode, respBody)
+		}
+		var tok struct {
+			AccessToken string `json:"access_token"`
+			Scope       string `json:"scope"`
+			TokenType   string `json:"token_type"`
+		}
+		if err := json.Unmarshal(respBody, &tok); err != nil {
+			t.Fatalf("decode token: %v", err)
+		}
+		if tok.AccessToken == "" || tok.Scope != "read" || tok.TokenType != "Bearer" {
+			t.Fatalf("unexpected token response: %+v", tok)
+		}
+	})
+
+	t.Run("register user with explicit role", func(t *testing.T) {
+		body := mustPostJSON(t, srv.URL+"/test/users", map[string]string{
+			"username": "alice@example.com",
+			"password": "hunter22",
+			"role":     "user",
+		})
+		var userResp struct {
+			ID, Username, Role string
+		}
+		if err := json.Unmarshal(body, &userResp); err != nil {
+			t.Fatalf("decode user: %v body=%s", err, body)
+		}
+		if userResp.Username != "alice@example.com" || userResp.Role != "user" {
+			t.Fatalf("unexpected user response: %+v", userResp)
+		}
+	})
+
+	t.Run("client missing key returns 400", func(t *testing.T) {
+		buf, _ := json.Marshal(map[string]string{"redirect_uri": "https://x"})
+		resp, err := http.Post(srv.URL+"/test/clients", "application/json", bytes.NewReader(buf))
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected 400 got %d", resp.StatusCode)
+		}
+	})
+}
+
+func TestProductionModeOmitsTestRoutes(t *testing.T) {
+	srv := newTestApp(t, false)
+	resp := mustGet(t, srv.URL+"/test/health")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 when test-mode is off, got %d", resp.StatusCode)
+	}
+}
+
+func mustGet(t *testing.T, u string) *http.Response {
+	t.Helper()
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET %s: %v", u, err)
+	}
+	return resp
+}
+
+func mustPostJSON(t *testing.T, u string, payload any) []byte {
+	t.Helper()
+	buf, _ := json.Marshal(payload)
+	resp, err := http.Post(u, "application/json", bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("POST %s: %v", u, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		t.Fatalf("POST %s: status %d body %s", u, resp.StatusCode, body)
+	}
+	return body
+}

--- a/testmode/routes.go
+++ b/testmode/routes.go
@@ -1,0 +1,36 @@
+package testmode
+
+import (
+	"github.com/RichardKnop/go-oauth2-server/util/routes"
+	"github.com/gorilla/mux"
+)
+
+// RegisterRoutes mounts /test/* control-plane routes under the given prefix.
+func (s *Service) RegisterRoutes(router *mux.Router, prefix string) {
+	subRouter := router.PathPrefix(prefix).Subrouter()
+	routes.AddRoutes(s.GetRoutes(), subRouter)
+}
+
+// GetRoutes returns the routes exposed by the test-mode control plane.
+func (s *Service) GetRoutes() []routes.Route {
+	return []routes.Route{
+		{
+			Name:        "test_health",
+			Method:      "GET",
+			Pattern:     "/health",
+			HandlerFunc: s.health,
+		},
+		{
+			Name:        "test_create_client",
+			Method:      "POST",
+			Pattern:     "/clients",
+			HandlerFunc: s.createClient,
+		},
+		{
+			Name:        "test_create_user",
+			Method:      "POST",
+			Pattern:     "/users",
+			HandlerFunc: s.createUser,
+		},
+	}
+}

--- a/testmode/seed.go
+++ b/testmode/seed.go
@@ -1,0 +1,39 @@
+package testmode
+
+import (
+	"time"
+
+	"github.com/RichardKnop/go-oauth2-server/models"
+	"github.com/RichardKnop/go-oauth2-server/oauth/roles"
+	"github.com/jinzhu/gorm"
+)
+
+// Seed inserts the minimum role and scope rows the OAuth service requires
+// to issue tokens. Mirrors oauth/fixtures/{roles,scopes}.yml.
+func Seed(db *gorm.DB) error {
+	now := time.Now().UTC()
+
+	defaultRoles := []models.OauthRole{
+		{ID: roles.Superuser, Name: "Superuser", TimestampModel: models.TimestampModel{CreatedAt: now, UpdatedAt: now}},
+		{ID: roles.User, Name: "User", TimestampModel: models.TimestampModel{CreatedAt: now, UpdatedAt: now}},
+	}
+	for i := range defaultRoles {
+		r := defaultRoles[i]
+		if err := db.FirstOrCreate(&r, models.OauthRole{ID: r.ID}).Error; err != nil {
+			return err
+		}
+	}
+
+	defaultScopes := []models.OauthScope{
+		{MyGormModel: models.MyGormModel{ID: "1", CreatedAt: now}, Scope: "read", IsDefault: true},
+		{MyGormModel: models.MyGormModel{ID: "2", CreatedAt: now}, Scope: "read_write", IsDefault: false},
+	}
+	for i := range defaultScopes {
+		sc := defaultScopes[i]
+		if err := db.FirstOrCreate(&sc, models.OauthScope{Scope: sc.Scope}).Error; err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/testmode/service.go
+++ b/testmode/service.go
@@ -1,0 +1,23 @@
+package testmode
+
+import (
+	"github.com/RichardKnop/go-oauth2-server/config"
+	"github.com/RichardKnop/go-oauth2-server/oauth"
+	"github.com/jinzhu/gorm"
+)
+
+// Service holds dependencies for the test-mode control plane.
+type Service struct {
+	cnf          *config.Config
+	db           *gorm.DB
+	oauthService oauth.ServiceInterface
+}
+
+// NewService constructs a test-mode service.
+func NewService(cnf *config.Config, db *gorm.DB, oauthService oauth.ServiceInterface) *Service {
+	return &Service{
+		cnf:          cnf,
+		db:           db,
+		oauthService: oauthService,
+	}
+}


### PR DESCRIPTION
Closes #3. Tracking: #2.

## Summary

Adds a `--test-mode` flag on `runserver` that boots the server without etcd/consul, using embedded SQLite, and exposes a control-plane API under `/test` for programmatic test setup. Production code paths are unchanged when the flag is off.

- New CLI flags: `--test-mode`, `--test-db-path` (default `:memory:`), `--test-port` (default 8080)
- New `testmode` package: in-memory `config.Config`, default scope/role seed, and `GET /test/health`, `POST /test/clients`, `POST /test/users`
- `database`: SQLite branch in `NewDatabase` with `PRAGMA foreign_keys = ON`
- `models/migrations`: skip `ALTER TABLE ADD FK` on SQLite (not supported by the engine); the postgres path is unchanged
- New `cmd/run_test_server.go` entrypoint that mounts `/test/*` alongside the existing `/v1/oauth/*` and `/web/*` routes only when `--test-mode` is on
- `testmode/integration_test.go` covers health, client+token round-trip via `client_credentials`, user creation with role default, missing-key 400, and `/test/*` returning 404 when test-mode is off

## Acceptance criteria

- [x] `runserver --test-mode` starts and binds with no external deps (verified via live smoke test against `:memory:`)
- [x] `GET /test/health` returns 200 with `{status:"ok", mode:"test"}`
- [x] `POST /test/clients` → use creds for `client_credentials` token grant → access token issued
- [x] `/test/*` returns 404 without `--test-mode`
- [x] `go test ./...` passes for all packages not bound to a live postgres (oauth/web suites still depend on postgres per existing setup)

## Notes / deferred

The `/test/clients` body accepts `scope` and `token_endpoint_auth_method` per the issue spec, but these are logged and ignored for now:

- `scope` per-client storage will land in PR-3 (#5) alongside the script queue's `scope_override`.
- `token_endpoint_auth_method` enforcement is PR-8 (#10).

Adding both fields here would have required schema migrations that belong with their feature work; accepting the fields now means clients/tests can pass them without breaking once those PRs land.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./testmode/...`
- [x] Live smoke: register client, register user, `client_credentials` grant, `password` grant
- [x] (Reviewer) try `runserver` without `--test-mode` and confirm the existing etcd-backed path still works