### PR TITLE
PR-2: Programmatic authorize + request inspection (G2, G8)

### DIFF
--- a/cmd/run_test_server.go
+++ b/cmd/run_test_server.go
@@ -44,18 +44,19 @@ func RunTestServer(dbPath string, port int) error {
 	}
 	defer services.Close()
 
+	testService := testmode.NewService(cnf, db, services.OauthService)
+
 	app := negroni.New()
 	app.Use(negroni.NewRecovery())
 	app.Use(negroni.NewLogger())
 	app.Use(gzip.Gzip(gzip.DefaultCompression))
 	app.Use(negroni.NewStatic(http.Dir("public")))
+	app.Use(testService.Middleware())
 
 	router := mux.NewRouter()
 	services.HealthService.RegisterRoutes(router, "/v1")
 	services.OauthService.RegisterRoutes(router, "/v1/oauth")
 	services.WebService.RegisterRoutes(router, "/web")
-
-	testService := testmode.NewService(cnf, db, services.OauthService)
 	testService.RegisterRoutes(router, "/test")
 
 	app.UseHandler(router)

--- a/testmode/authorize.go
+++ b/testmode/authorize.go
@@ -1,0 +1,180 @@
+package testmode
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/RichardKnop/go-oauth2-server/log"
+	"github.com/RichardKnop/go-oauth2-server/models"
+	"github.com/RichardKnop/go-oauth2-server/oauth"
+	"github.com/RichardKnop/go-oauth2-server/util/response"
+)
+
+// parseSince accepts RFC3339 or a Unix-second integer string for ergonomic
+// cli/script use.
+func parseSince(s string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t, nil
+	}
+	return time.Parse(time.RFC3339, s)
+}
+
+type authorizeRequest struct {
+	ClientID            string `json:"client_id"`
+	UserID              string `json:"user_id"`
+	Username            string `json:"username,omitempty"`
+	RedirectURI         string `json:"redirect_uri"`
+	Scope               string `json:"scope"`
+	State               string `json:"state"`
+	Decision            string `json:"decision"`
+	GrantedScope        string `json:"granted_scope,omitempty"`
+	CodeChallenge       string `json:"code_challenge,omitempty"`
+	CodeChallengeMethod string `json:"code_challenge_method,omitempty"`
+}
+
+type authorizeResponse struct {
+	RedirectURL string `json:"redirect_url"`
+}
+
+// authorize implements POST /test/authorize. It bypasses the HTML/session
+// flow and produces the redirect URL the proxy would have followed after
+// the user clicked approve or deny.
+func (s *Service) authorize(w http.ResponseWriter, r *http.Request) {
+	var req authorizeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		response.Error(w, "invalid JSON body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.ClientID == "" {
+		response.Error(w, "client_id is required", http.StatusBadRequest)
+		return
+	}
+	if req.RedirectURI == "" {
+		response.Error(w, "redirect_uri is required", http.StatusBadRequest)
+		return
+	}
+	if req.Decision != "approve" && req.Decision != "deny" {
+		response.Error(w, `decision must be "approve" or "deny"`, http.StatusBadRequest)
+		return
+	}
+
+	if req.CodeChallenge != "" || req.CodeChallengeMethod != "" {
+		log.INFO.Printf("testmode: /test/authorize received code_challenge=%q method=%q "+
+			"(accepted but not yet enforced; see PR-7)",
+			req.CodeChallenge, req.CodeChallengeMethod)
+	}
+
+	client, err := s.oauthService.FindClientByClientID(req.ClientID)
+	if err != nil {
+		response.Error(w, "client not found: "+req.ClientID, http.StatusNotFound)
+		return
+	}
+
+	// Validate redirect_uri against the registered URI when one is set.
+	if client.RedirectURI.Valid && client.RedirectURI.String != "" {
+		if client.RedirectURI.String != req.RedirectURI {
+			response.Error(w, "redirect_uri does not match registered URI", http.StatusBadRequest)
+			return
+		}
+	}
+
+	redirectURL, err := url.Parse(req.RedirectURI)
+	if err != nil {
+		response.Error(w, "invalid redirect_uri: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Deny: short-circuit with error redirect; no user lookup required.
+	if req.Decision == "deny" {
+		q := redirectURL.Query()
+		q.Set("error", "access_denied")
+		if req.State != "" {
+			q.Set("state", req.State)
+		}
+		redirectURL.RawQuery = q.Encode()
+		response.WriteJSON(w, authorizeResponse{RedirectURL: redirectURL.String()}, http.StatusOK)
+		return
+	}
+
+	user, err := s.findUser(req.UserID, req.Username)
+	if err != nil {
+		response.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	scopeForCode := req.GrantedScope
+	if scopeForCode == "" {
+		scopeForCode = req.Scope
+	}
+	resolvedScope, err := s.oauthService.GetScope(scopeForCode)
+	if err != nil {
+		response.Error(w, "invalid scope: "+scopeForCode, http.StatusBadRequest)
+		return
+	}
+
+	authCode, err := s.oauthService.GrantAuthorizationCode(
+		client,
+		user,
+		s.cnf.Oauth.AuthCodeLifetime,
+		req.RedirectURI,
+		resolvedScope,
+	)
+	if err != nil {
+		response.Error(w, "granting authorization code: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	q := redirectURL.Query()
+	q.Set("code", authCode.Code)
+	if req.State != "" {
+		q.Set("state", req.State)
+	}
+	redirectURL.RawQuery = q.Encode()
+	response.WriteJSON(w, authorizeResponse{RedirectURL: redirectURL.String()}, http.StatusOK)
+}
+
+// findUser resolves a user by UUID or username. user_id is preferred per
+// the spec; username is accepted as a convenience for tests that don't
+// want to track UUIDs.
+func (s *Service) findUser(userID, username string) (*models.OauthUser, error) {
+	if userID == "" && username == "" {
+		return nil, errors.New("user_id or username is required")
+	}
+	if userID != "" {
+		var user models.OauthUser
+		notFound := s.db.Where("id = ?", userID).First(&user).RecordNotFound()
+		if notFound {
+			return nil, errors.New("user not found: " + userID)
+		}
+		return &user, nil
+	}
+	user, err := s.oauthService.FindUserByUsername(username)
+	if err != nil {
+		if errors.Is(err, oauth.ErrUserNotFound) {
+			return nil, errors.New("user not found: " + username)
+		}
+		return nil, err
+	}
+	return user, nil
+}
+
+// requestsHandler implements GET /test/requests.
+func (s *Service) requestsHandler(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	filter := SnapshotFilter{
+		Endpoint: q.Get("endpoint"),
+		ClientID: q.Get("client_id"),
+	}
+	if since := q.Get("since"); since != "" {
+		t, err := parseSince(since)
+		if err != nil {
+			response.Error(w, "invalid since: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		filter.Since = t
+	}
+	response.WriteJSON(w, s.recorder.Snapshot(filter), http.StatusOK)
+}

--- a/testmode/integration_test.go
+++ b/testmode/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/RichardKnop/go-oauth2-server/database"
 	"github.com/RichardKnop/go-oauth2-server/models"
@@ -16,9 +17,15 @@ import (
 	"github.com/RichardKnop/go-oauth2-server/testmode"
 	"github.com/RichardKnop/go-oauth2-server/util/migrations"
 	"github.com/gorilla/mux"
+	"github.com/urfave/negroni"
 )
 
-func newTestApp(t *testing.T, withTestMode bool) *httptest.Server {
+type testApp struct {
+	server   *httptest.Server
+	recorder *testmode.Recorder
+}
+
+func newTestApp(t *testing.T, withTestMode bool) *testApp {
 	t.Helper()
 
 	cnf := testmode.NewConfig(":memory:")
@@ -42,18 +49,24 @@ func newTestApp(t *testing.T, withTestMode bool) *httptest.Server {
 	oauthService := oauth.NewService(cnf, db)
 	oauthService.RegisterRoutes(router, "/v1/oauth")
 
+	app := negroni.New()
+	var rec *testmode.Recorder
 	if withTestMode {
 		ts := testmode.NewService(cnf, db, oauthService)
+		app.Use(ts.Middleware())
 		ts.RegisterRoutes(router, "/test")
+		rec = ts.Recorder()
 	}
+	app.UseHandler(router)
 
-	srv := httptest.NewServer(router)
+	srv := httptest.NewServer(app)
 	t.Cleanup(srv.Close)
-	return srv
+	return &testApp{server: srv, recorder: rec}
 }
 
 func TestTestModeBootstrap(t *testing.T) {
-	srv := newTestApp(t, true)
+	app := newTestApp(t, true)
+	srv := app.server
 
 	t.Run("health", func(t *testing.T) {
 		resp := mustGet(t, srv.URL+"/test/health")
@@ -145,12 +158,273 @@ func TestTestModeBootstrap(t *testing.T) {
 }
 
 func TestProductionModeOmitsTestRoutes(t *testing.T) {
-	srv := newTestApp(t, false)
-	resp := mustGet(t, srv.URL+"/test/health")
+	app := newTestApp(t, false)
+	resp := mustGet(t, app.server.URL+"/test/health")
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected 404 when test-mode is off, got %d", resp.StatusCode)
 	}
+}
+
+func TestProgrammaticAuthorize(t *testing.T) {
+	app := newTestApp(t, true)
+	srv := app.server
+
+	// Setup: register client and user.
+	clientBody := mustPostJSON(t, srv.URL+"/test/clients", map[string]string{
+		"key":          "auth-client",
+		"secret":       "topsecret",
+		"redirect_uri": "https://app.example.com/cb",
+	})
+	var client struct{ ID, Key, RedirectURI string }
+	json.Unmarshal(clientBody, &client)
+
+	userBody := mustPostJSON(t, srv.URL+"/test/users", map[string]string{
+		"username": "bob@example.com",
+		"password": "hunter22",
+	})
+	var user struct{ ID, Username, Role string }
+	json.Unmarshal(userBody, &user)
+
+	t.Run("approve returns redirect with code and round-trips through tokens endpoint", func(t *testing.T) {
+		body := mustPostJSON(t, srv.URL+"/test/authorize", map[string]string{
+			"client_id":    "auth-client",
+			"user_id":      user.ID,
+			"redirect_uri": "https://app.example.com/cb",
+			"scope":        "read",
+			"state":        "xyzzy",
+			"decision":     "approve",
+		})
+		var resp struct{ RedirectURL string `json:"redirect_url"` }
+		if err := json.Unmarshal(body, &resp); err != nil {
+			t.Fatalf("decode authorize body: %v", err)
+		}
+		u, err := url.Parse(resp.RedirectURL)
+		if err != nil {
+			t.Fatalf("parse redirect: %v", err)
+		}
+		if u.Host != "app.example.com" || u.Path != "/cb" {
+			t.Fatalf("unexpected redirect host/path: %s", resp.RedirectURL)
+		}
+		code := u.Query().Get("code")
+		if code == "" {
+			t.Fatalf("expected code in redirect: %s", resp.RedirectURL)
+		}
+		if got := u.Query().Get("state"); got != "xyzzy" {
+			t.Fatalf("expected state=xyzzy got %q", got)
+		}
+
+		// Exchange the code for tokens.
+		form := url.Values{}
+		form.Set("grant_type", "authorization_code")
+		form.Set("code", code)
+		form.Set("redirect_uri", "https://app.example.com/cb")
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth("auth-client", "topsecret")
+		tokenResp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("token request: %v", err)
+		}
+		body2, _ := io.ReadAll(tokenResp.Body)
+		tokenResp.Body.Close()
+		if tokenResp.StatusCode != http.StatusOK {
+			t.Fatalf("expected token 200, got %d body=%s", tokenResp.StatusCode, body2)
+		}
+		var tok struct {
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+		}
+		json.Unmarshal(body2, &tok)
+		if tok.AccessToken == "" {
+			t.Fatalf("expected access_token in response, got %s", body2)
+		}
+	})
+
+	t.Run("deny returns redirect with error=access_denied", func(t *testing.T) {
+		body := mustPostJSON(t, srv.URL+"/test/authorize", map[string]string{
+			"client_id":    "auth-client",
+			"user_id":      user.ID,
+			"redirect_uri": "https://app.example.com/cb",
+			"scope":        "read",
+			"state":        "denied-state",
+			"decision":     "deny",
+		})
+		var resp struct{ RedirectURL string `json:"redirect_url"` }
+		json.Unmarshal(body, &resp)
+		u, _ := url.Parse(resp.RedirectURL)
+		if got := u.Query().Get("error"); got != "access_denied" {
+			t.Fatalf("expected error=access_denied got %q", got)
+		}
+		if got := u.Query().Get("state"); got != "denied-state" {
+			t.Fatalf("expected state denied-state got %q", got)
+		}
+		if got := u.Query().Get("code"); got != "" {
+			t.Fatalf("deny should not include code, got %q", got)
+		}
+	})
+
+	t.Run("redirect_uri mismatch returns 400", func(t *testing.T) {
+		buf, _ := json.Marshal(map[string]string{
+			"client_id":    "auth-client",
+			"user_id":      user.ID,
+			"redirect_uri": "https://evil.example.com/cb",
+			"scope":        "read",
+			"decision":     "approve",
+		})
+		resp, err := http.Post(srv.URL+"/test/authorize", "application/json", bytes.NewReader(buf))
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected 400 got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("granted_scope narrows the granted scope", func(t *testing.T) {
+		// scope=read_write requested, granted_scope=read narrows it.
+		body := mustPostJSON(t, srv.URL+"/test/authorize", map[string]string{
+			"client_id":     "auth-client",
+			"user_id":       user.ID,
+			"redirect_uri":  "https://app.example.com/cb",
+			"scope":         "read_write",
+			"granted_scope": "read",
+			"decision":      "approve",
+		})
+		var resp struct{ RedirectURL string `json:"redirect_url"` }
+		json.Unmarshal(body, &resp)
+		u, _ := url.Parse(resp.RedirectURL)
+		code := u.Query().Get("code")
+
+		form := url.Values{}
+		form.Set("grant_type", "authorization_code")
+		form.Set("code", code)
+		form.Set("redirect_uri", "https://app.example.com/cb")
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth("auth-client", "topsecret")
+		tokenResp, _ := http.DefaultClient.Do(req)
+		body2, _ := io.ReadAll(tokenResp.Body)
+		tokenResp.Body.Close()
+		var tok struct{ Scope string }
+		json.Unmarshal(body2, &tok)
+		if tok.Scope != "read" {
+			t.Fatalf("expected granted scope=read, got %q (full: %s)", tok.Scope, body2)
+		}
+	})
+}
+
+func TestRequestRecording(t *testing.T) {
+	app := newTestApp(t, true)
+	srv := app.server
+
+	mustPostJSON(t, srv.URL+"/test/clients", map[string]string{
+		"key":          "rec-client",
+		"secret":       "rec-secret",
+		"redirect_uri": "https://x.example.com/cb",
+	})
+
+	// Issue a token request — should be recorded.
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("scope", "read")
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth("rec-client", "rec-secret")
+	tokenResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	tokenResp.Body.Close()
+
+	t.Run("GET /test/requests returns the token call with sanitized headers", func(t *testing.T) {
+		resp := mustGet(t, srv.URL+"/test/requests?endpoint=token")
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		var entries []testmode.RecordedRequest
+		if err := json.Unmarshal(body, &entries); err != nil {
+			t.Fatalf("decode: %v body=%s", err, body)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 entry got %d: %s", len(entries), body)
+		}
+		e := entries[0]
+		if e.Path != "/v1/oauth/tokens" || e.Method != "POST" || e.Endpoint != "token" {
+			t.Fatalf("unexpected entry: %+v", e)
+		}
+		if e.ClientID != "rec-client" {
+			t.Fatalf("expected client_id rec-client, got %q", e.ClientID)
+		}
+		if got := e.Headers["Authorization"]; got != "Basic <redacted>" {
+			t.Fatalf("expected Authorization redacted, got %q", got)
+		}
+		if e.Form["grant_type"] == nil || e.Form["grant_type"][0] != "client_credentials" {
+			t.Fatalf("expected grant_type recorded, got %v", e.Form)
+		}
+	})
+
+	t.Run("password grant redacts password form field", func(t *testing.T) {
+		// Create user.
+		mustPostJSON(t, srv.URL+"/test/users", map[string]string{
+			"username": "carol@example.com",
+			"password": "hunter22",
+		})
+		form := url.Values{}
+		form.Set("grant_type", "password")
+		form.Set("username", "carol@example.com")
+		form.Set("password", "hunter22")
+		form.Set("scope", "read")
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth("rec-client", "rec-secret")
+		resp, _ := http.DefaultClient.Do(req)
+		resp.Body.Close()
+
+		// Snapshot all token-endpoint records and assert the latest password
+		// grant has the password redacted.
+		entries := app.recorder.Snapshot(testmode.SnapshotFilter{Endpoint: "token"})
+		var pwdEntry *testmode.RecordedRequest
+		for i := range entries {
+			if entries[i].Form["grant_type"] != nil && entries[i].Form["grant_type"][0] == "password" {
+				pwdEntry = &entries[i]
+			}
+		}
+		if pwdEntry == nil {
+			t.Fatalf("no password-grant entry found")
+		}
+		if got := pwdEntry.Form["password"]; len(got) != 1 || got[0] != "<redacted>" {
+			t.Fatalf("password should be redacted, got %v", got)
+		}
+		if got := pwdEntry.Form["client_secret"]; got != nil {
+			// client_secret is in Basic auth here, not form, so it should be
+			// absent from the form. But if form contained it, it should be redacted.
+			if got[0] != "<redacted>" {
+				t.Fatalf("client_secret in form should be redacted, got %v", got)
+			}
+		}
+	})
+
+	t.Run("since filter works", func(t *testing.T) {
+		future := time.Now().UTC().Add(1 * time.Hour).Format(time.RFC3339)
+		resp := mustGet(t, srv.URL+"/test/requests?since="+url.QueryEscape(future))
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		var entries []testmode.RecordedRequest
+		json.Unmarshal(body, &entries)
+		if len(entries) != 0 {
+			t.Fatalf("expected 0 entries from future since, got %d", len(entries))
+		}
+	})
+
+	t.Run("/test/* control endpoints are not recorded", func(t *testing.T) {
+		entries := app.recorder.Snapshot(testmode.SnapshotFilter{})
+		for _, e := range entries {
+			if strings.HasPrefix(e.Path, "/test/") {
+				t.Fatalf("control-plane path should not be recorded: %s", e.Path)
+			}
+		}
+	})
 }
 
 func mustGet(t *testing.T, u string) *http.Response {

--- a/testmode/recorder.go
+++ b/testmode/recorder.go
@@ -1,0 +1,206 @@
+package testmode
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultRecorderCapacity is the maximum number of requests retained.
+const DefaultRecorderCapacity = 1000
+
+// RecordedRequest is a sanitized snapshot of a request that hit a recorded
+// endpoint. Secrets are redacted; the Authorization header preserves the
+// scheme so tests can assert on auth method without leaking credentials.
+type RecordedRequest struct {
+	Timestamp time.Time           `json:"timestamp"`
+	Method    string              `json:"method"`
+	Path      string              `json:"path"`
+	Endpoint  string              `json:"endpoint"`
+	ClientID  string              `json:"client_id,omitempty"`
+	Headers   map[string]string   `json:"headers"`
+	Query     map[string][]string `json:"query,omitempty"`
+	Form      map[string][]string `json:"form,omitempty"`
+}
+
+// Recorder is a bounded, thread-safe ring buffer of RecordedRequest.
+type Recorder struct {
+	mu       sync.Mutex
+	cap      int
+	entries  []RecordedRequest
+	inserted int
+}
+
+// NewRecorder constructs a Recorder with the given capacity. Capacity <= 0
+// uses DefaultRecorderCapacity.
+func NewRecorder(capacity int) *Recorder {
+	if capacity <= 0 {
+		capacity = DefaultRecorderCapacity
+	}
+	return &Recorder{cap: capacity, entries: make([]RecordedRequest, 0, capacity)}
+}
+
+// Record appends an entry, dropping the oldest when at capacity.
+func (r *Recorder) Record(entry RecordedRequest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.inserted++
+	if len(r.entries) < r.cap {
+		r.entries = append(r.entries, entry)
+		return
+	}
+	// Shift left and append.
+	copy(r.entries, r.entries[1:])
+	r.entries[len(r.entries)-1] = entry
+}
+
+// Snapshot returns a copy of recorded entries, optionally filtered.
+type SnapshotFilter struct {
+	Endpoint string
+	ClientID string
+	Since    time.Time
+}
+
+// Snapshot returns matching entries in chronological order.
+func (r *Recorder) Snapshot(f SnapshotFilter) []RecordedRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]RecordedRequest, 0, len(r.entries))
+	for _, e := range r.entries {
+		if f.Endpoint != "" && e.Endpoint != f.Endpoint {
+			continue
+		}
+		if f.ClientID != "" && e.ClientID != f.ClientID {
+			continue
+		}
+		if !f.Since.IsZero() && e.Timestamp.Before(f.Since) {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// Reset clears all recorded entries (test helper).
+func (r *Recorder) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.entries = r.entries[:0]
+	r.inserted = 0
+}
+
+// classifyEndpoint maps a request path (and form for token/refresh) to an
+// endpoint label. Returns the empty string for paths that should not be
+// recorded.
+func classifyEndpoint(path string, form url.Values) string {
+	switch {
+	case path == "/v1/oauth/tokens":
+		if form.Get("grant_type") == "refresh_token" {
+			return "refresh"
+		}
+		return "token"
+	case path == "/v1/oauth/introspect":
+		return "introspect"
+	case path == "/v1/oauth/revoke":
+		return "revoke"
+	case strings.HasPrefix(path, "/test/resource"):
+		return "resource"
+	default:
+		return ""
+	}
+}
+
+// redactedFormFields are stripped from recorded requests. Authorization
+// header values are also redacted (scheme preserved) by sanitizeHeaders.
+var redactedFormFields = map[string]struct{}{
+	"client_secret": {},
+	"password":      {},
+	"code_verifier": {},
+	"refresh_token": {},
+}
+
+// sanitizeHeaders copies headers, redacts Authorization values to keep just
+// the scheme, and drops cookies.
+func sanitizeHeaders(h http.Header) map[string]string {
+	out := make(map[string]string, len(h))
+	for name, values := range h {
+		canonical := http.CanonicalHeaderKey(name)
+		switch canonical {
+		case "Cookie", "Set-Cookie":
+			continue
+		case "Authorization":
+			if len(values) == 0 {
+				continue
+			}
+			parts := strings.SplitN(values[0], " ", 2)
+			if len(parts) == 2 && parts[1] != "" {
+				out[canonical] = parts[0] + " <redacted>"
+			} else {
+				out[canonical] = "<redacted>"
+			}
+		default:
+			out[canonical] = strings.Join(values, ", ")
+		}
+	}
+	return out
+}
+
+// sanitizeForm copies form values and redacts known credential fields.
+func sanitizeForm(form url.Values) map[string][]string {
+	if len(form) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(form))
+	for k, v := range form {
+		if _, redact := redactedFormFields[strings.ToLower(k)]; redact {
+			out[k] = []string{"<redacted>"}
+			continue
+		}
+		out[k] = append([]string(nil), v...)
+	}
+	return out
+}
+
+// extractClientID pulls a client identifier from Basic auth or form fields,
+// preferring Basic auth (the spec authenticates clients there).
+func extractClientID(r *http.Request, form url.Values) string {
+	if user, _, ok := r.BasicAuth(); ok && user != "" {
+		return user
+	}
+	return form.Get("client_id")
+}
+
+// recorderMiddleware is a negroni-compatible middleware that records every
+// request whose path classifyEndpoint recognizes.
+type recorderMiddleware struct {
+	rec *Recorder
+}
+
+func (m *recorderMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	// Parsing the form here is safe: ParseForm caches r.PostForm/r.Form, so
+	// downstream handlers calling it again are no-ops. ParseForm only reads
+	// the body for application/x-www-form-urlencoded requests, which is
+	// what the OAuth endpoints use.
+	_ = r.ParseForm()
+
+	endpoint := classifyEndpoint(r.URL.Path, r.PostForm)
+	if endpoint == "" {
+		next(w, r)
+		return
+	}
+
+	entry := RecordedRequest{
+		Timestamp: time.Now().UTC(),
+		Method:    r.Method,
+		Path:      r.URL.Path,
+		Endpoint:  endpoint,
+		ClientID:  extractClientID(r, r.PostForm),
+		Headers:   sanitizeHeaders(r.Header),
+		Query:     map[string][]string(r.URL.Query()),
+		Form:      sanitizeForm(r.PostForm),
+	}
+	m.rec.Record(entry)
+	next(w, r)
+}

--- a/testmode/routes.go
+++ b/testmode/routes.go
@@ -32,5 +32,17 @@ func (s *Service) GetRoutes() []routes.Route {
 			Pattern:     "/users",
 			HandlerFunc: s.createUser,
 		},
+		{
+			Name:        "test_authorize",
+			Method:      "POST",
+			Pattern:     "/authorize",
+			HandlerFunc: s.authorize,
+		},
+		{
+			Name:        "test_requests",
+			Method:      "GET",
+			Pattern:     "/requests",
+			HandlerFunc: s.requestsHandler,
+		},
 	}
 }

--- a/testmode/service.go
+++ b/testmode/service.go
@@ -11,6 +11,7 @@ type Service struct {
 	cnf          *config.Config
 	db           *gorm.DB
 	oauthService oauth.ServiceInterface
+	recorder     *Recorder
 }
 
 // NewService constructs a test-mode service.
@@ -19,5 +20,18 @@ func NewService(cnf *config.Config, db *gorm.DB, oauthService oauth.ServiceInter
 		cnf:          cnf,
 		db:           db,
 		oauthService: oauthService,
+		recorder:     NewRecorder(0),
 	}
+}
+
+// Recorder returns the request recorder so callers (run_test_server.go) can
+// install the recording middleware.
+func (s *Service) Recorder() *Recorder {
+	return s.recorder
+}
+
+// Middleware returns a negroni-compatible middleware that records requests
+// matching classifyEndpoint.
+func (s *Service) Middleware() *recorderMiddleware {
+	return &recorderMiddleware{rec: s.recorder}
 }


### PR DESCRIPTION
Closes #4. Tracking: #2.

## Summary

Adds two test-mode capabilities:

- **`POST /test/authorize`** — drives the authorize step programmatically. Accepts `client_id`, `user_id` (or `username`), `redirect_uri`, `scope`, `state`, `decision`, `granted_scope?`. Returns `{redirect_url}` with `code+state` on approve, or `error=access_denied` on deny. Bypasses the HTML/session flow that AuthProxy can't drive.
- **Request recording** — sanitized snapshots of every request that hits `/v1/oauth/*` (and `/test/resource/*` when PR-6 lands). Bounded ring buffer (default 1000 entries). `GET /test/requests` returns the buffer with optional `endpoint=`, `since=`, `client_id=` filters.

## Sanitization

- `Authorization` header: scheme preserved, value redacted — e.g. `Basic <redacted>`, `Bearer <redacted>`.
- Form fields `client_secret`, `password`, `code_verifier`, `refresh_token` → `<redacted>`.
- `Cookie` / `Set-Cookie` dropped entirely.
- Endpoint label is derived from the path (and `grant_type` for `/v1/oauth/tokens`): `token`, `refresh`, `introspect`, `revoke`, `resource`.

## Acceptance criteria

- [x] Approve flow: register client+user → `POST /test/authorize` → exchange `code` → access token (verified live and in `TestProgrammaticAuthorize`).
- [x] Deny path returns `redirect_url` with `error=access_denied` and original `state`.
- [x] `GET /test/requests?endpoint=token` returns the token call with `Authorization: Basic <redacted>`.
- [x] `/test/*` is 404 when `--test-mode` is off; `/test/*` requests are not recorded.

## Notes / deferred

- `code_challenge` / `code_challenge_method` are accepted on `/test/authorize` but only logged. Real PKCE validation is PR-7 (#9), which adds the schema columns and verifier check at `/v1/oauth/tokens`.
- `granted_scope` works against the existing `OauthScope` table; it lets tests narrow what the client actually got vs. what was requested.
- The recorder middleware is wired in `cmd/run_test_server.go` only — production `RunServer` is untouched.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./testmode/...` (5 subtests for authorize, 4 for recording)
- [x] Live: approve → token exchange, deny → access_denied, token call appears in `/test/requests` with redacted Authorization
- [ ] (Reviewer) confirm production `runserver` (no `--test-mode`) still binds and serves /v1/oauth/* without the recorder middleware