### PR TITLE
PR-3: Scriptable response queues (G3, G4)

### DIFF
--- a/cmd/run_test_server.go
+++ b/cmd/run_test_server.go
@@ -49,9 +49,13 @@ func RunTestServer(dbPath string, port int) error {
 	app := negroni.New()
 	app.Use(negroni.NewRecovery())
 	app.Use(negroni.NewLogger())
+	// Recorder + script middleware run BEFORE gzip so script-injected
+	// responses (and hijacked connections for drop_connection) bypass the
+	// gzip writer wrap.
+	app.Use(testService.Middleware())
+	app.Use(testService.ScriptMiddleware())
 	app.Use(gzip.Gzip(gzip.DefaultCompression))
 	app.Use(negroni.NewStatic(http.Dir("public")))
-	app.Use(testService.Middleware())
 
 	router := mux.NewRouter()
 	services.HealthService.RegisterRoutes(router, "/v1")

--- a/testmode/integration_test.go
+++ b/testmode/integration_test.go
@@ -54,6 +54,7 @@ func newTestApp(t *testing.T, withTestMode bool) *testApp {
 	if withTestMode {
 		ts := testmode.NewService(cnf, db, oauthService)
 		app.Use(ts.Middleware())
+		app.Use(ts.ScriptMiddleware())
 		ts.RegisterRoutes(router, "/test")
 		rec = ts.Recorder()
 	}
@@ -423,6 +424,198 @@ func TestRequestRecording(t *testing.T) {
 			if strings.HasPrefix(e.Path, "/test/") {
 				t.Fatalf("control-plane path should not be recorded: %s", e.Path)
 			}
+		}
+	})
+}
+
+func TestScriptQueue(t *testing.T) {
+	app := newTestApp(t, true)
+	srv := app.server
+
+	mustPostJSON(t, srv.URL+"/test/clients", map[string]string{
+		"key":          "scr-client",
+		"secret":       "scr-secret",
+		"redirect_uri": "https://x.example.com/cb",
+	})
+
+	tokenCall := func(t *testing.T) *http.Response {
+		t.Helper()
+		form := url.Values{}
+		form.Set("grant_type", "client_credentials")
+		form.Set("scope", "read")
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth("scr-client", "scr-secret")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("token: %v", err)
+		}
+		return resp
+	}
+
+	t.Run("queued 503 then real handler success", func(t *testing.T) {
+		// Enqueue one 503 action. Next call should be 503; the call after
+		// that should fall through to the real handler.
+		buf, _ := json.Marshal(map[string]any{
+			"client_id": "scr-client",
+			"endpoint":  "token",
+			"actions": []map[string]any{
+				{"body_template": "temporarily_unavailable_503"},
+			},
+		})
+		resp, _ := http.Post(srv.URL+"/test/scripts", "application/json", bytes.NewReader(buf))
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("expected 204 from /test/scripts, got %d", resp.StatusCode)
+		}
+		resp.Body.Close()
+
+		first := tokenCall(t)
+		if first.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("expected 503, got %d", first.StatusCode)
+		}
+		first.Body.Close()
+
+		second := tokenCall(t)
+		body, _ := io.ReadAll(second.Body)
+		second.Body.Close()
+		if second.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 fall-through, got %d body=%s", second.StatusCode, body)
+		}
+	})
+
+	t.Run("scope_override empty string omits scope from response", func(t *testing.T) {
+		emptyScope := ""
+		buf, _ := json.Marshal(map[string]any{
+			"client_id": "scr-client",
+			"endpoint":  "token",
+			"actions": []map[string]any{
+				{"scope_override": &emptyScope},
+			},
+		})
+		http.Post(srv.URL+"/test/scripts", "application/json", bytes.NewReader(buf))
+
+		resp := tokenCall(t)
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		var generic map[string]any
+		json.Unmarshal(body, &generic)
+		if _, has := generic["scope"]; has {
+			t.Fatalf("expected scope omitted, got %s", body)
+		}
+		if _, has := generic["access_token"]; !has {
+			t.Fatalf("expected access_token still present, got %s", body)
+		}
+	})
+
+	t.Run("scope_override non-empty replaces scope", func(t *testing.T) {
+		newScope := "narrowed"
+		buf, _ := json.Marshal(map[string]any{
+			"client_id": "scr-client",
+			"endpoint":  "token",
+			"actions": []map[string]any{
+				{"scope_override": &newScope},
+			},
+		})
+		http.Post(srv.URL+"/test/scripts", "application/json", bytes.NewReader(buf))
+
+		resp := tokenCall(t)
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		var generic map[string]any
+		json.Unmarshal(body, &generic)
+		if generic["scope"] != "narrowed" {
+			t.Fatalf("expected scope=narrowed, got %v (body=%s)", generic["scope"], body)
+		}
+	})
+
+	t.Run("fail_count repeats then drops", func(t *testing.T) {
+		buf, _ := json.Marshal(map[string]any{
+			"client_id": "scr-client",
+			"endpoint":  "token",
+			"actions": []map[string]any{
+				{"status": 418, "body": `{"e":"teapot"}`, "fail_count": 2},
+			},
+		})
+		http.Post(srv.URL+"/test/scripts", "application/json", bytes.NewReader(buf))
+
+		first := tokenCall(t)
+		first.Body.Close()
+		second := tokenCall(t)
+		second.Body.Close()
+		third := tokenCall(t)
+		third.Body.Close()
+
+		if first.StatusCode != 418 || second.StatusCode != 418 {
+			t.Fatalf("expected 418,418 got %d,%d", first.StatusCode, second.StatusCode)
+		}
+		if third.StatusCode != http.StatusOK {
+			t.Fatalf("third call should fall through to 200, got %d", third.StatusCode)
+		}
+	})
+
+	t.Run("wildcard client_id matches any caller", func(t *testing.T) {
+		buf, _ := json.Marshal(map[string]any{
+			// no client_id
+			"endpoint": "token",
+			"actions":  []map[string]any{{"status": 599, "body": `{}`}},
+		})
+		http.Post(srv.URL+"/test/scripts", "application/json", bytes.NewReader(buf))
+
+		resp := tokenCall(t)
+		resp.Body.Close()
+		if resp.StatusCode != 599 {
+			t.Fatalf("expected wildcard to match, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("DELETE clears queues", func(t *testing.T) {
+		buf, _ := json.Marshal(map[string]any{
+			"client_id": "scr-client",
+			"endpoint":  "token",
+			"actions":   []map[string]any{{"status": 599, "body": `{}`}},
+		})
+		http.Post(srv.URL+"/test/scripts", "application/json", bytes.NewReader(buf))
+
+		req, _ := http.NewRequest("DELETE", srv.URL+"/test/scripts", nil)
+		resp, _ := http.DefaultClient.Do(req)
+		resp.Body.Close()
+
+		listResp := mustGet(t, srv.URL+"/test/scripts")
+		body, _ := io.ReadAll(listResp.Body)
+		listResp.Body.Close()
+		var snap []testmode.QueueSnapshot
+		json.Unmarshal(body, &snap)
+		if len(snap) != 0 {
+			t.Fatalf("expected empty snapshot, got %v", snap)
+		}
+
+		// Token call should fall through.
+		fall := tokenCall(t)
+		fall.Body.Close()
+		if fall.StatusCode != http.StatusOK {
+			t.Fatalf("expected fall-through 200 after clear, got %d", fall.StatusCode)
+		}
+	})
+
+	t.Run("drop_connection causes client read error", func(t *testing.T) {
+		buf, _ := json.Marshal(map[string]any{
+			"client_id": "scr-client",
+			"endpoint":  "token",
+			"actions":   []map[string]any{{"drop_connection": true}},
+		})
+		http.Post(srv.URL+"/test/scripts", "application/json", bytes.NewReader(buf))
+
+		// Use a non-keepalive client so we see the close cleanly.
+		client := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+		form := url.Values{}
+		form.Set("grant_type", "client_credentials")
+		form.Set("scope", "read")
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth("scr-client", "scr-secret")
+		_, err := client.Do(req)
+		if err == nil {
+			t.Fatalf("expected connection error from drop_connection, got nil")
 		}
 	})
 }

--- a/testmode/routes.go
+++ b/testmode/routes.go
@@ -44,5 +44,23 @@ func (s *Service) GetRoutes() []routes.Route {
 			Pattern:     "/requests",
 			HandlerFunc: s.requestsHandler,
 		},
+		{
+			Name:        "test_enqueue_script",
+			Method:      "POST",
+			Pattern:     "/scripts",
+			HandlerFunc: s.enqueueScript,
+		},
+		{
+			Name:        "test_list_scripts",
+			Method:      "GET",
+			Pattern:     "/scripts",
+			HandlerFunc: s.listScripts,
+		},
+		{
+			Name:        "test_clear_scripts",
+			Method:      "DELETE",
+			Pattern:     "/scripts",
+			HandlerFunc: s.clearScripts,
+		},
 	}
 }

--- a/testmode/scripts.go
+++ b/testmode/scripts.go
@@ -1,0 +1,149 @@
+package testmode
+
+import (
+	"sync"
+)
+
+// Action describes one scripted response on a queue. Actions are popped in
+// FIFO order. An action with a non-zero Status fully replaces the response
+// (skips the real handler); a status-zero action with ScopeOverride set
+// passes through to the real handler and rewrites its JSON `scope` field.
+type Action struct {
+	// Network behavior.
+	Status         int               `json:"status,omitempty"`
+	Headers        map[string]string `json:"headers,omitempty"`
+	Body           string            `json:"body,omitempty"`
+	BodyTemplate   string            `json:"body_template,omitempty"`
+	DelayMS        int               `json:"delay_ms,omitempty"`
+	DropConnection bool              `json:"drop_connection,omitempty"`
+
+	// FailCount applies this action this many times before it is removed
+	// from the queue. Zero (or negative) means apply exactly once.
+	FailCount int `json:"fail_count,omitempty"`
+
+	// ScopeOverride rewrites the `scope` field of a JSON token response when
+	// the action passes through (Status == 0). Pointer-typed so the empty
+	// string can encode "omit scope from the response entirely".
+	ScopeOverride *string `json:"scope_override,omitempty"`
+
+	// SkipPKCECheck is forward-declared for PR-7. Currently a no-op.
+	SkipPKCECheck bool `json:"skip_pkce_check,omitempty"`
+
+	// remaining tracks how many more times this action should fire. Set on
+	// enqueue based on FailCount; not exposed in JSON snapshots.
+	remaining int
+}
+
+// queueKey identifies a per-(client, endpoint) FIFO. clientID == "" is the
+// wildcard queue used when no client-specific queue is set.
+type queueKey struct {
+	clientID string
+	endpoint string
+}
+
+// ScriptQueue holds per-client/endpoint action queues with FIFO semantics.
+type ScriptQueue struct {
+	mu     sync.Mutex
+	queues map[queueKey][]Action
+}
+
+// NewScriptQueue constructs an empty queue.
+func NewScriptQueue() *ScriptQueue {
+	return &ScriptQueue{queues: make(map[queueKey][]Action)}
+}
+
+// Enqueue appends actions to the queue for (clientID, endpoint). Empty
+// clientID enqueues onto the wildcard queue.
+func (q *ScriptQueue) Enqueue(clientID, endpoint string, actions []Action) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	prepared := make([]Action, len(actions))
+	for i, a := range actions {
+		if a.FailCount > 0 {
+			a.remaining = a.FailCount
+		} else {
+			a.remaining = 1
+		}
+		prepared[i] = a
+	}
+	k := queueKey{clientID: clientID, endpoint: endpoint}
+	q.queues[k] = append(q.queues[k], prepared...)
+}
+
+// Pop returns the next action for a request from clientID at endpoint,
+// preferring a client-specific queue over the wildcard queue. The action's
+// remaining count is decremented; when it reaches zero the action is
+// removed from the queue.
+func (q *ScriptQueue) Pop(clientID, endpoint string) (Action, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if a, ok := q.popLocked(queueKey{clientID: clientID, endpoint: endpoint}); ok {
+		return a, true
+	}
+	if clientID != "" {
+		if a, ok := q.popLocked(queueKey{clientID: "", endpoint: endpoint}); ok {
+			return a, true
+		}
+	}
+	return Action{}, false
+}
+
+func (q *ScriptQueue) popLocked(k queueKey) (Action, bool) {
+	queue := q.queues[k]
+	if len(queue) == 0 {
+		return Action{}, false
+	}
+	a := queue[0]
+	a.remaining--
+	if a.remaining <= 0 {
+		queue = queue[1:]
+	} else {
+		queue[0].remaining = a.remaining
+	}
+	if len(queue) == 0 {
+		delete(q.queues, k)
+	} else {
+		q.queues[k] = queue
+	}
+	return a, true
+}
+
+// QueueSnapshot is one (clientID, endpoint, actions) tuple as returned by
+// GET /test/scripts.
+type QueueSnapshot struct {
+	ClientID string   `json:"client_id"`
+	Endpoint string   `json:"endpoint"`
+	Actions  []Action `json:"actions"`
+}
+
+// Snapshot returns the remaining actions across all queues.
+func (q *ScriptQueue) Snapshot() []QueueSnapshot {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	out := make([]QueueSnapshot, 0, len(q.queues))
+	for k, actions := range q.queues {
+		out = append(out, QueueSnapshot{
+			ClientID: k.clientID,
+			Endpoint: k.endpoint,
+			Actions:  append([]Action(nil), actions...),
+		})
+	}
+	return out
+}
+
+// Clear removes queues matching the filter. Empty fields match anything.
+func (q *ScriptQueue) Clear(clientID, endpoint string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for k := range q.queues {
+		if clientID != "" && k.clientID != clientID {
+			continue
+		}
+		if endpoint != "" && k.endpoint != endpoint {
+			continue
+		}
+		delete(q.queues, k)
+	}
+}

--- a/testmode/scripts_handlers.go
+++ b/testmode/scripts_handlers.go
@@ -1,0 +1,66 @@
+package testmode
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/RichardKnop/go-oauth2-server/util/response"
+)
+
+type enqueueScriptRequest struct {
+	ClientID string   `json:"client_id"`
+	Endpoint string   `json:"endpoint"`
+	Actions  []Action `json:"actions"`
+}
+
+var validScriptEndpoints = map[string]struct{}{
+	"token":      {},
+	"refresh":    {},
+	"revoke":     {},
+	"resource":   {},
+	"introspect": {},
+}
+
+// enqueueScript implements POST /test/scripts.
+func (s *Service) enqueueScript(w http.ResponseWriter, r *http.Request) {
+	var req enqueueScriptRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		response.Error(w, "invalid JSON body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Endpoint == "" {
+		response.Error(w, "endpoint is required", http.StatusBadRequest)
+		return
+	}
+	if _, ok := validScriptEndpoints[req.Endpoint]; !ok {
+		response.Error(w, "unknown endpoint: "+req.Endpoint, http.StatusBadRequest)
+		return
+	}
+	if len(req.Actions) == 0 {
+		response.Error(w, "at least one action is required", http.StatusBadRequest)
+		return
+	}
+	for _, a := range req.Actions {
+		if a.BodyTemplate != "" {
+			if _, ok := templateAction(a.BodyTemplate); !ok {
+				response.Error(w, "unknown body_template: "+a.BodyTemplate, http.StatusBadRequest)
+				return
+			}
+		}
+	}
+
+	s.queue.Enqueue(req.ClientID, req.Endpoint, req.Actions)
+	response.NoContent(w)
+}
+
+// listScripts implements GET /test/scripts.
+func (s *Service) listScripts(w http.ResponseWriter, r *http.Request) {
+	response.WriteJSON(w, s.queue.Snapshot(), http.StatusOK)
+}
+
+// clearScripts implements DELETE /test/scripts.
+func (s *Service) clearScripts(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	s.queue.Clear(q.Get("client_id"), q.Get("endpoint"))
+	response.NoContent(w)
+}

--- a/testmode/scripts_middleware.go
+++ b/testmode/scripts_middleware.go
@@ -1,0 +1,155 @@
+package testmode
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/RichardKnop/go-oauth2-server/log"
+)
+
+// scriptMiddleware applies queued Actions to incoming requests bound for
+// recordable OAuth endpoints.
+type scriptMiddleware struct {
+	queue *ScriptQueue
+}
+
+func (m *scriptMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	_ = r.ParseForm()
+	endpoint := classifyEndpoint(r.URL.Path, r.PostForm)
+	if endpoint == "" {
+		next(w, r)
+		return
+	}
+
+	clientID := extractClientID(r, r.PostForm)
+	action, ok := m.queue.Pop(clientID, endpoint)
+	if !ok {
+		next(w, r)
+		return
+	}
+	action = resolveTemplate(action)
+
+	if action.DelayMS > 0 {
+		time.Sleep(time.Duration(action.DelayMS) * time.Millisecond)
+	}
+
+	if action.DropConnection {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			log.ERROR.Print("testmode: drop_connection requested but writer is not a Hijacker")
+			http.Error(w, "drop_connection unsupported on this writer", http.StatusInternalServerError)
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			log.ERROR.Printf("testmode: hijack failed: %v", err)
+			return
+		}
+		_ = conn.Close()
+		return
+	}
+
+	// Pass-through with scope_override: run the real handler, then rewrite
+	// the JSON `scope` field on the way out.
+	if action.Status == 0 && action.ScopeOverride != nil {
+		applyScopeOverride(w, r, next, *action.ScopeOverride)
+		return
+	}
+
+	// Pass-through without overrides: ignore (let handler run).
+	if action.Status == 0 && action.Body == "" {
+		next(w, r)
+		return
+	}
+
+	// Full replacement.
+	for k, v := range action.Headers {
+		w.Header().Set(k, v)
+	}
+	if w.Header().Get("Content-Type") == "" {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	}
+	if w.Header().Get("Content-Length") == "" {
+		w.Header().Set("Content-Length", strconv.Itoa(len(action.Body)))
+	}
+	status := action.Status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(action.Body))
+}
+
+// applyScopeOverride runs next() against a buffering writer, then rewrites
+// the JSON body's `scope` field. An empty override removes the field.
+func applyScopeOverride(w http.ResponseWriter, r *http.Request, next http.HandlerFunc, override string) {
+	bw := &bufferingWriter{header: http.Header{}, body: &bytes.Buffer{}}
+	next(bw, r)
+
+	// Try to parse the body as JSON object and rewrite `scope`.
+	var obj map[string]any
+	if err := json.Unmarshal(bw.body.Bytes(), &obj); err == nil {
+		if override == "" {
+			delete(obj, "scope")
+		} else {
+			obj["scope"] = override
+		}
+		newBody, _ := json.Marshal(obj)
+		// Copy headers but override Content-Length.
+		for k, vs := range bw.header {
+			for _, v := range vs {
+				w.Header().Add(k, v)
+			}
+		}
+		w.Header().Set("Content-Length", strconv.Itoa(len(newBody)))
+		status := bw.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write(newBody)
+		return
+	}
+
+	// Body wasn't JSON — pass through verbatim.
+	for k, vs := range bw.header {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	status := bw.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	w.WriteHeader(status)
+	_, _ = w.Write(bw.body.Bytes())
+}
+
+// bufferingWriter captures status, headers, and body so a middleware can
+// post-process the downstream handler's response.
+type bufferingWriter struct {
+	header      http.Header
+	status      int
+	body        *bytes.Buffer
+	wroteHeader bool
+}
+
+func (b *bufferingWriter) Header() http.Header { return b.header }
+
+func (b *bufferingWriter) WriteHeader(code int) {
+	if b.wroteHeader {
+		return
+	}
+	b.status = code
+	b.wroteHeader = true
+}
+
+func (b *bufferingWriter) Write(p []byte) (int, error) {
+	if !b.wroteHeader {
+		b.WriteHeader(http.StatusOK)
+	}
+	return b.body.Write(p)
+}

--- a/testmode/scripts_templates.go
+++ b/testmode/scripts_templates.go
@@ -1,0 +1,72 @@
+package testmode
+
+import "net/http"
+
+// templateAction returns a base Action populated from a built-in template
+// name. Explicit fields on the user-provided Action override the template
+// defaults.
+//
+// Recognized templates:
+//   - access_token_success: 200 with a sample bearer token + scope
+//   - access_token_no_scope: 200 with a sample bearer token, no scope field
+//   - invalid_grant: 400 {"error":"invalid_grant"}
+//   - temporarily_unavailable_503: 503 {"error":"temporarily_unavailable"}
+//   - malformed_json: 200 with a deliberately malformed body
+func templateAction(name string) (Action, bool) {
+	switch name {
+	case "access_token_success":
+		return Action{
+			Status:  http.StatusOK,
+			Headers: map[string]string{"Content-Type": "application/json"},
+			Body:    `{"access_token":"00000000-0000-4000-8000-000000000000","expires_in":3600,"token_type":"Bearer","scope":"read"}`,
+		}, true
+	case "access_token_no_scope":
+		return Action{
+			Status:  http.StatusOK,
+			Headers: map[string]string{"Content-Type": "application/json"},
+			Body:    `{"access_token":"00000000-0000-4000-8000-000000000000","expires_in":3600,"token_type":"Bearer"}`,
+		}, true
+	case "invalid_grant":
+		return Action{
+			Status:  http.StatusBadRequest,
+			Headers: map[string]string{"Content-Type": "application/json"},
+			Body:    `{"error":"invalid_grant"}`,
+		}, true
+	case "temporarily_unavailable_503":
+		return Action{
+			Status:  http.StatusServiceUnavailable,
+			Headers: map[string]string{"Content-Type": "application/json"},
+			Body:    `{"error":"temporarily_unavailable"}`,
+		}, true
+	case "malformed_json":
+		return Action{
+			Status:  http.StatusOK,
+			Headers: map[string]string{"Content-Type": "application/json"},
+			Body:    `{not valid json`,
+		}, true
+	default:
+		return Action{}, false
+	}
+}
+
+// resolveTemplate fills in defaults from the template named by a.BodyTemplate
+// when the caller did not specify a Status or Body explicitly.
+func resolveTemplate(a Action) Action {
+	if a.BodyTemplate == "" {
+		return a
+	}
+	tpl, ok := templateAction(a.BodyTemplate)
+	if !ok {
+		return a
+	}
+	if a.Status == 0 {
+		a.Status = tpl.Status
+	}
+	if a.Body == "" {
+		a.Body = tpl.Body
+	}
+	if len(a.Headers) == 0 {
+		a.Headers = tpl.Headers
+	}
+	return a
+}

--- a/testmode/service.go
+++ b/testmode/service.go
@@ -12,6 +12,7 @@ type Service struct {
 	db           *gorm.DB
 	oauthService oauth.ServiceInterface
 	recorder     *Recorder
+	queue        *ScriptQueue
 }
 
 // NewService constructs a test-mode service.
@@ -21,6 +22,7 @@ func NewService(cnf *config.Config, db *gorm.DB, oauthService oauth.ServiceInter
 		db:           db,
 		oauthService: oauthService,
 		recorder:     NewRecorder(0),
+		queue:        NewScriptQueue(),
 	}
 }
 
@@ -30,8 +32,19 @@ func (s *Service) Recorder() *Recorder {
 	return s.recorder
 }
 
+// Queue returns the script queue.
+func (s *Service) Queue() *ScriptQueue {
+	return s.queue
+}
+
 // Middleware returns a negroni-compatible middleware that records requests
 // matching classifyEndpoint.
 func (s *Service) Middleware() *recorderMiddleware {
 	return &recorderMiddleware{rec: s.recorder}
+}
+
+// ScriptMiddleware returns a negroni-compatible middleware that intercepts
+// requests using queued Actions.
+func (s *Service) ScriptMiddleware() *scriptMiddleware {
+	return &scriptMiddleware{queue: s.queue}
 }


### PR DESCRIPTION
Closes #5. Tracking: #2.

## Summary

Adds a per-(client_id, endpoint) FIFO of `Action` objects that the test harness can enqueue, and a middleware that pops one off when a recordable OAuth endpoint is hit. With this, tests can simulate transient 5xx, malformed bodies, dropped connections, scope variations, and arbitrary status/body without changing server code.

## API

- `POST /test/scripts` — enqueue actions. Body: `{client_id?, endpoint, actions: [...]}`. `client_id == ""` is a wildcard queue consulted when no client-specific action is set.
- `GET  /test/scripts` — return remaining actions across all queues.
- `DELETE /test/scripts?client_id=&endpoint=` — clear matching queues.

`endpoint` ∈ {`token`, `refresh`, `revoke`, `resource`, `introspect`}. Same labels the recorder (#4) uses; `revoke`/`resource` are reserved for PR-5/PR-6.

## Action shape

| field | behavior |
| --- | --- |
| `status`, `body`, `headers` | full replacement; skip the real handler |
| `body_template` | named template fills in defaults; explicit fields override |
| `delay_ms` | sleep before responding |
| `drop_connection` | hijack the conn and close it |
| `fail_count` | repeat the action N times before removing (default once) |
| `scope_override` (`*string`) | pass-through: run real handler, rewrite JSON `scope` (empty string ⇒ omit) |
| `skip_pkce_check` | reserved for PR-7; ignored today |

Built-in `body_template`s: `access_token_success`, `access_token_no_scope`, `invalid_grant`, `temporarily_unavailable_503`, `malformed_json`.

## Acceptance criteria

- [x] Queue 503 → call → 503; second call → 200 fall-through
- [x] `scope_override: ""` → next token response omits `scope`
- [x] `scope_override: "narrowed"` → next token response replaces `scope`
- [x] `drop_connection: true` → client sees connection error
- [x] `fail_count: 2` → action applied twice, then dropped
- [x] Wildcard (no `client_id`) matches any caller for that endpoint
- [x] DELETE clears queues; subsequent calls fall through
- [x] `/test/scripts` is 404 when `--test-mode` is off (covered by existing test)

## Notes / wiring

- Middleware order in `cmd/run_test_server.go`: recovery → logger → recorder → script → gzip → static → router. Script sits before gzip so direct response writes and hijacked connections don't pass through the gzip wrap.
- `scope_override` uses a buffering ResponseWriter to capture the real handler's body and rewrites the JSON. If the body isn't valid JSON, it passes through verbatim.
- `fail_count: 0` (or unset) ≡ apply once. `fail_count: N>0` ≡ apply N times.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./testmode/...` (7 new subtests for the queue + the existing 4 recording subtests still green)
- [x] Live: enqueue 503 template → first call 503, second call 200, queue empty
- [ ] (Reviewer) verify production `runserver` (no `--test-mode`) still works without the script middleware