### PR TITLE
PR-4: Refresh token rotation (G5)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,13 @@ type OauthConfig struct {
 	AccessTokenLifetime  int
 	RefreshTokenLifetime int
 	AuthCodeLifetime     int
+
+	// RefreshTokenRotation, when true, issues a new refresh token on every
+	// `grant_type=refresh_token` exchange and revokes the prior one. The
+	// new token's parent_id links back to the prior token for chain
+	// inspection. Default off in production; the test-mode config sets it
+	// to true so harnesses can exercise rotation by default.
+	RefreshTokenRotation bool
 }
 
 // SessionConfig stores session configuration for the web app

--- a/database/database.go
+++ b/database/database.go
@@ -64,6 +64,12 @@ func NewDatabase(cnf *config.Config) (*gorm.DB, error) {
 			return db, err
 		}
 
+		// SQLite serializes writes anyway; with ":memory:" each pooled
+		// connection would also get its own private database, which makes
+		// concurrent test traffic see partial state. Cap the pool at 1 so
+		// every query lands on the same connection and the same DB.
+		db.DB().SetMaxOpenConns(1)
+
 		db.LogMode(cnf.IsDevelopment)
 		return db, nil
 	}

--- a/models/migrations.go
+++ b/models/migrations.go
@@ -13,6 +13,10 @@ var (
 			Name:     "initial",
 			Function: migrate0001,
 		},
+		{
+			Name:     "refresh_token_rotation",
+			Function: migrate0002,
+		},
 	}
 )
 
@@ -113,5 +117,16 @@ func migrate0001(db *gorm.DB, name string) error {
 			"oauth_authorization_codes.user_id for oauth_users(id): %s", err)
 	}
 
+	return nil
+}
+
+// migrate0002 adds the columns required for refresh-token rotation:
+// revoked_at and parent_id on oauth_refresh_tokens. AutoMigrate is
+// additive — it adds missing columns without touching existing data,
+// so this is safe to run against an existing prod database.
+func migrate0002(db *gorm.DB, name string) error {
+	if err := db.AutoMigrate(new(OauthRefreshToken)).Error; err != nil {
+		return fmt.Errorf("Error adding refresh-token rotation columns: %s", err)
+	}
 	return nil
 }

--- a/models/oauth.go
+++ b/models/oauth.go
@@ -71,6 +71,14 @@ type OauthRefreshToken struct {
 	Token     string    `sql:"type:varchar(40);unique;not null"`
 	ExpiresAt time.Time `sql:"not null"`
 	Scope     string    `sql:"type:varchar(200);not null"`
+
+	// RevokedAt is set by refresh-token rotation (and later by RFC 7009
+	// revocation). A non-nil value means the token can no longer be used.
+	RevokedAt *time.Time `sql:"index"`
+
+	// ParentID points to the refresh token this one was rotated from, so
+	// reuse of an ancestor in the chain is detectable. Null on the root.
+	ParentID sql.NullString `sql:"type:varchar(36)"`
 }
 
 // TableName specifies table name

--- a/oauth/errors.go
+++ b/oauth/errors.go
@@ -13,6 +13,7 @@ var (
 		ErrInvalidUsernameOrPassword:     http.StatusBadRequest,
 		ErrRefreshTokenNotFound:          http.StatusNotFound,
 		ErrRefreshTokenExpired:           http.StatusBadRequest,
+		ErrRefreshTokenRevoked:           http.StatusBadRequest,
 		ErrRequestedScopeCannotBeGreater: http.StatusBadRequest,
 		ErrTokenMissing:                  http.StatusNotFound,
 		ErrTokenHintInvalid:              http.StatusBadRequest,

--- a/oauth/grant_type_refresh_token.go
+++ b/oauth/grant_type_refresh_token.go
@@ -20,12 +20,20 @@ func (s *Service) refreshTokenGrant(r *http.Request, client *models.OauthClient)
 		return nil, err
 	}
 
-	// Log in the user
-	accessToken, refreshToken, err := s.Login(
-		theRefreshToken.Client,
-		theRefreshToken.User,
-		scope,
+	var (
+		accessToken  *models.OauthAccessToken
+		refreshToken *models.OauthRefreshToken
 	)
+	if s.cnf.Oauth.RefreshTokenRotation {
+		accessToken, refreshToken, err = s.rotateRefreshToken(theRefreshToken, scope)
+	} else {
+		// Legacy non-rotation path: reuses the existing refresh token.
+		accessToken, refreshToken, err = s.Login(
+			theRefreshToken.Client,
+			theRefreshToken.User,
+			scope,
+		)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/oauth/refresh_token.go
+++ b/oauth/refresh_token.go
@@ -13,6 +13,10 @@ var (
 	ErrRefreshTokenNotFound = errors.New("Refresh token not found")
 	// ErrRefreshTokenExpired ...
 	ErrRefreshTokenExpired = errors.New("Refresh token expired")
+	// ErrRefreshTokenRevoked is returned when a refresh token has been
+	// rotated or otherwise marked revoked. Maps to HTTP 400 (invalid_grant
+	// in OAuth terms).
+	ErrRefreshTokenRevoked = errors.New("Refresh token revoked")
 	// ErrRequestedScopeCannotBeGreater ...
 	ErrRequestedScopeCannotBeGreater = errors.New("Requested scope cannot be greater")
 )
@@ -20,9 +24,13 @@ var (
 // GetOrCreateRefreshToken retrieves an existing refresh token, if expired,
 // the token gets deleted and new refresh token is created
 func (s *Service) GetOrCreateRefreshToken(client *models.OauthClient, user *models.OauthUser, expiresIn int, scope string) (*models.OauthRefreshToken, error) {
-	// Try to fetch an existing refresh token first
+	// Try to fetch an existing refresh token first. Revoked tokens (from
+	// rotation or RFC 7009 revocation) are treated as not-found so a fresh
+	// token is issued.
 	refreshToken := new(models.OauthRefreshToken)
-	query := models.OauthRefreshTokenPreload(s.db).Where("client_id = ?", client.ID)
+	query := models.OauthRefreshTokenPreload(s.db).
+		Where("client_id = ?", client.ID).
+		Where("revoked_at IS NULL")
 	if user != nil && len([]rune(user.ID)) > 0 {
 		query = query.Where("user_id = ?", user.ID)
 	} else {
@@ -64,6 +72,12 @@ func (s *Service) GetValidRefreshToken(token string, client *models.OauthClient)
 	// Not found
 	if notFound {
 		return nil, ErrRefreshTokenNotFound
+	}
+
+	// Check the refresh token hasn't been revoked (e.g. by a prior rotation
+	// or RFC 7009 revocation).
+	if refreshToken.RevokedAt != nil {
+		return nil, ErrRefreshTokenRevoked
 	}
 
 	// Check the refresh token hasn't expired

--- a/oauth/refresh_token_rotation.go
+++ b/oauth/refresh_token_rotation.go
@@ -1,0 +1,74 @@
+package oauth
+
+import (
+	"time"
+
+	"github.com/RichardKnop/go-oauth2-server/models"
+	"github.com/RichardKnop/go-oauth2-server/util"
+)
+
+// rotateRefreshToken is the rotation-on path for grant_type=refresh_token.
+// It atomically marks the old token revoked and issues a new (access,
+// refresh) pair linked back to it via parent_id.
+//
+// Concurrency: the revoke is a CAS update of the form
+//
+//	UPDATE oauth_refresh_tokens SET revoked_at = ?
+//	 WHERE id = ? AND revoked_at IS NULL
+//
+// so two simultaneous refresh requests for the same token race on the same
+// row: exactly one update affects 1 row, the other affects 0 and gets
+// ErrRefreshTokenRevoked back.
+func (s *Service) rotateRefreshToken(old *models.OauthRefreshToken, scope string) (*models.OauthAccessToken, *models.OauthRefreshToken, error) {
+	if old.User != nil && !s.IsRoleAllowed(old.User.RoleID.String) {
+		return nil, nil, ErrInvalidUsernameOrPassword
+	}
+
+	tx := s.db.Begin()
+	if tx.Error != nil {
+		return nil, nil, tx.Error
+	}
+
+	now := time.Now().UTC()
+	res := tx.Model(new(models.OauthRefreshToken)).
+		Where("id = ? AND revoked_at IS NULL", old.ID).
+		Update("revoked_at", now)
+	if res.Error != nil {
+		tx.Rollback()
+		return nil, nil, res.Error
+	}
+	if res.RowsAffected != 1 {
+		tx.Rollback()
+		return nil, nil, ErrRefreshTokenRevoked
+	}
+
+	// New access token. We don't reuse GrantAccessToken because that opens
+	// its own transaction and would deadlock here on SQLite.
+	accessToken := models.NewOauthAccessToken(
+		old.Client, old.User, s.cnf.Oauth.AccessTokenLifetime, scope,
+	)
+	if err := tx.Create(accessToken).Error; err != nil {
+		tx.Rollback()
+		return nil, nil, err
+	}
+	accessToken.Client = old.Client
+	accessToken.User = old.User
+
+	// New refresh token, linked to the old one.
+	refreshToken := models.NewOauthRefreshToken(
+		old.Client, old.User, s.cnf.Oauth.RefreshTokenLifetime, scope,
+	)
+	refreshToken.ParentID = util.StringOrNull(old.ID)
+	if err := tx.Create(refreshToken).Error; err != nil {
+		tx.Rollback()
+		return nil, nil, err
+	}
+	refreshToken.Client = old.Client
+	refreshToken.User = old.User
+
+	if err := tx.Commit().Error; err != nil {
+		tx.Rollback()
+		return nil, nil, err
+	}
+	return accessToken, refreshToken, nil
+}

--- a/testmode/config.go
+++ b/testmode/config.go
@@ -19,6 +19,7 @@ func NewConfig(dbPath string) *config.Config {
 			AccessTokenLifetime:  3600,
 			RefreshTokenLifetime: 1209600,
 			AuthCodeLifetime:     3600,
+			RefreshTokenRotation: true, // tests usually want rotation; toggle via /test/refresh-tokens/rotate-policy
 		},
 		Session: config.SessionConfig{
 			Secret:   "test_secret",

--- a/testmode/integration_test.go
+++ b/testmode/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -616,6 +617,168 @@ func TestScriptQueue(t *testing.T) {
 		_, err := client.Do(req)
 		if err == nil {
 			t.Fatalf("expected connection error from drop_connection, got nil")
+		}
+	})
+}
+
+func TestRefreshTokenRotation(t *testing.T) {
+	app := newTestApp(t, true)
+	srv := app.server
+
+	// Setup: client + user.
+	mustPostJSON(t, srv.URL+"/test/clients", map[string]string{
+		"key":          "rot-client",
+		"secret":       "rot-secret",
+		"redirect_uri": "https://x.example.com/cb",
+	})
+	mustPostJSON(t, srv.URL+"/test/users", map[string]string{
+		"username": "dave@example.com",
+		"password": "hunter22",
+	})
+
+	// Get an initial refresh token via password grant.
+	initialRefreshToken := func(t *testing.T) string {
+		t.Helper()
+		form := url.Values{}
+		form.Set("grant_type", "password")
+		form.Set("username", "dave@example.com")
+		form.Set("password", "hunter22")
+		form.Set("scope", "read")
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth("rot-client", "rot-secret")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("password grant: %v", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		var tok struct {
+			RefreshToken string `json:"refresh_token"`
+		}
+		json.Unmarshal(body, &tok)
+		if tok.RefreshToken == "" {
+			t.Fatalf("expected refresh_token in response, got %s", body)
+		}
+		return tok.RefreshToken
+	}
+
+	doRefresh := func(t *testing.T, rt string) (status int, body []byte) {
+		t.Helper()
+		form := url.Values{}
+		form.Set("grant_type", "refresh_token")
+		form.Set("refresh_token", rt)
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth("rot-client", "rot-secret")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("refresh: %v", err)
+		}
+		body, _ = io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return resp.StatusCode, body
+	}
+
+	t.Run("rotation issues a new refresh token and revokes the old", func(t *testing.T) {
+		rt := initialRefreshToken(t)
+
+		status, body := doRefresh(t, rt)
+		if status != http.StatusOK {
+			t.Fatalf("first refresh expected 200 got %d body=%s", status, body)
+		}
+		var refreshResp struct {
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+		}
+		json.Unmarshal(body, &refreshResp)
+		if refreshResp.RefreshToken == "" || refreshResp.RefreshToken == rt {
+			t.Fatalf("expected a new refresh token, got %q (was %q)", refreshResp.RefreshToken, rt)
+		}
+
+		// Replay the OLD refresh token: must fail (revoked).
+		status2, body2 := doRefresh(t, rt)
+		if status2 == http.StatusOK {
+			t.Fatalf("expected reuse of old refresh token to fail, got 200 body=%s", body2)
+		}
+		if status2 != http.StatusBadRequest {
+			t.Fatalf("expected 400 on revoked-token reuse, got %d body=%s", status2, body2)
+		}
+
+		// New refresh token still works.
+		status3, body3 := doRefresh(t, refreshResp.RefreshToken)
+		if status3 != http.StatusOK {
+			t.Fatalf("new refresh token should work, got %d body=%s", status3, body3)
+		}
+	})
+
+	t.Run("concurrent refresh: exactly one wins", func(t *testing.T) {
+		rt := initialRefreshToken(t)
+
+		const N = 8
+		var wg sync.WaitGroup
+		results := make([]int, N)
+		for i := 0; i < N; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				status, _ := doRefresh(t, rt)
+				results[i] = status
+			}(i)
+		}
+		wg.Wait()
+
+		ok, fail := 0, 0
+		for _, s := range results {
+			switch s {
+			case http.StatusOK:
+				ok++
+			case http.StatusBadRequest:
+				fail++
+			default:
+				t.Fatalf("unexpected status from concurrent refresh: %d", s)
+			}
+		}
+		if ok != 1 {
+			t.Fatalf("expected exactly 1 success across %d concurrent refreshes, got %d (results=%v)", N, ok, results)
+		}
+		if fail != N-1 {
+			t.Fatalf("expected %d failures, got %d (results=%v)", N-1, fail, results)
+		}
+	})
+
+	t.Run("rotate-policy off: legacy reuse behavior", func(t *testing.T) {
+		// Toggle rotation off.
+		buf, _ := json.Marshal(map[string]bool{"rotation": false})
+		resp, _ := http.Post(srv.URL+"/test/refresh-tokens/rotate-policy", "application/json", bytes.NewReader(buf))
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 from rotate-policy, got %d", resp.StatusCode)
+		}
+		resp.Body.Close()
+		t.Cleanup(func() {
+			// Restore default for subsequent subtests.
+			b, _ := json.Marshal(map[string]bool{"rotation": true})
+			r, _ := http.Post(srv.URL+"/test/refresh-tokens/rotate-policy", "application/json", bytes.NewReader(b))
+			r.Body.Close()
+		})
+
+		rt := initialRefreshToken(t)
+		status, body := doRefresh(t, rt)
+		if status != http.StatusOK {
+			t.Fatalf("first refresh expected 200, got %d body=%s", status, body)
+		}
+		var refreshResp struct {
+			RefreshToken string `json:"refresh_token"`
+		}
+		json.Unmarshal(body, &refreshResp)
+		if refreshResp.RefreshToken != rt {
+			t.Fatalf("with rotation off, refresh token should be reused; got %q expected %q", refreshResp.RefreshToken, rt)
+		}
+
+		// Replay the same refresh token: must still succeed.
+		status2, body2 := doRefresh(t, rt)
+		if status2 != http.StatusOK {
+			t.Fatalf("with rotation off, reuse should succeed; got %d body=%s", status2, body2)
 		}
 	})
 }

--- a/testmode/refresh_policy.go
+++ b/testmode/refresh_policy.go
@@ -1,0 +1,33 @@
+package testmode
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/RichardKnop/go-oauth2-server/util/response"
+)
+
+type rotatePolicyRequest struct {
+	Rotation *bool `json:"rotation"`
+}
+
+type rotatePolicyResponse struct {
+	Rotation bool `json:"rotation"`
+}
+
+// rotatePolicy implements POST /test/refresh-tokens/rotate-policy. It mutates
+// the in-memory config so subsequent refresh-token grants either rotate or
+// reuse the existing refresh token. This is test-mode only.
+func (s *Service) rotatePolicy(w http.ResponseWriter, r *http.Request) {
+	var req rotatePolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		response.Error(w, "invalid JSON body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Rotation == nil {
+		response.Error(w, "rotation field is required", http.StatusBadRequest)
+		return
+	}
+	s.cnf.Oauth.RefreshTokenRotation = *req.Rotation
+	response.WriteJSON(w, rotatePolicyResponse{Rotation: *req.Rotation}, http.StatusOK)
+}

--- a/testmode/routes.go
+++ b/testmode/routes.go
@@ -62,5 +62,11 @@ func (s *Service) GetRoutes() []routes.Route {
 			Pattern:     "/scripts",
 			HandlerFunc: s.clearScripts,
 		},
+		{
+			Name:        "test_rotate_policy",
+			Method:      "POST",
+			Pattern:     "/refresh-tokens/rotate-policy",
+			HandlerFunc: s.rotatePolicy,
+		},
 	}
 }


### PR DESCRIPTION
Closes #6. Tracking: #2.

## Summary

Adds `OauthConfig.RefreshTokenRotation`. When on, every `grant_type=refresh_token` exchange:

- Issues a brand-new refresh token (and access token) and returns it.
- Revokes the prior refresh token in the same DB transaction via a CAS update — `UPDATE oauth_refresh_tokens SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL`. Concurrent refreshes of the same token race on this update, so exactly one wins; the others get `ErrRefreshTokenRevoked` (HTTP 400).
- Links the new refresh token's `parent_id` to the old one for chain inspection.

Production default: `false` (legacy reuse — existing tests/behavior preserved). Test mode defaults to `true`. `POST /test/refresh-tokens/rotate-policy` body `{rotation: true|false}` toggles the in-memory config per test.

## Schema

`migrate0002` calls `AutoMigrate(new(OauthRefreshToken))`, which adds two nullable columns (`revoked_at`, `parent_id`) without touching existing rows. Safe to run against prod.

## Code changes

- `OauthRefreshToken` gains `RevokedAt *time.Time` and `ParentID sql.NullString`.
- `GetValidRefreshToken` rejects `RevokedAt != nil` with `ErrRefreshTokenRevoked`.
- `GetOrCreateRefreshToken` filters out revoked tokens (else the password/auth-code grant paths could hand back a dead token after a prior rotation).
- New `oauth/refresh_token_rotation.go` holds `rotateRefreshToken`. It runs the CAS-revoke + new-token-creation in a `tx.Begin()/Commit()`. The new access token is created inline rather than via `GrantAccessToken` because that helper opens its own tx and would deadlock on SQLite.
- `refreshTokenGrant` branches on the rotation flag: rotation path or legacy `Login` path.

## Database fix bundled

SQLite `:memory:` opens a *separate* in-memory database per pooled connection, so concurrent test traffic was hitting different DBs and seeing partial state (concurrent test got 401 invalid_client because the registered client wasn't on every connection). Capping `MaxOpenConns(1)` for SQLite keeps the pool on a single connection. SQLite serializes writes anyway.

## Acceptance criteria

- [x] Rotation on: refresh once → old token rejected with HTTP 400; new token works
- [x] Replay of an already-rotated refresh token fails with `invalid_grant` (HTTP 400) before it expires
- [x] 8 concurrent refreshes of the same token: exactly 1 success, 7 failures
- [x] Rotation off: existing reuse behavior preserved
- [x] Existing oauth and web suites still compile

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./testmode/...` (3 new subtests for rotation + all prior subtests still green)
- [x] Live: rotation issues new RT, replay of old returns 400, new RT works, toggle to off succeeds
- [ ] (Reviewer) verify production `runserver` (etcd-backed) still works; the migration is additive but deserves a smoke check on a real postgres