### PR TITLE
PR-5: Token revocation RFC 7009 (G6)

### DIFF
--- a/models/migrations.go
+++ b/models/migrations.go
@@ -17,6 +17,10 @@ var (
 			Name:     "refresh_token_rotation",
 			Function: migrate0002,
 		},
+		{
+			Name:     "access_token_revocation",
+			Function: migrate0003,
+		},
 	}
 )
 
@@ -127,6 +131,16 @@ func migrate0001(db *gorm.DB, name string) error {
 func migrate0002(db *gorm.DB, name string) error {
 	if err := db.AutoMigrate(new(OauthRefreshToken)).Error; err != nil {
 		return fmt.Errorf("Error adding refresh-token rotation columns: %s", err)
+	}
+	return nil
+}
+
+// migrate0003 adds revoked_at to oauth_access_tokens so RFC 7009
+// revocation (and the refresh-token cascade) can mark access tokens
+// invalid without deleting their rows. Additive.
+func migrate0003(db *gorm.DB, name string) error {
+	if err := db.AutoMigrate(new(OauthAccessToken)).Error; err != nil {
+		return fmt.Errorf("Error adding access-token revocation column: %s", err)
 	}
 	return nil
 }

--- a/models/oauth.go
+++ b/models/oauth.go
@@ -96,6 +96,10 @@ type OauthAccessToken struct {
 	Token     string    `sql:"type:varchar(40);unique;not null"`
 	ExpiresAt time.Time `sql:"not null"`
 	Scope     string    `sql:"type:varchar(200);not null"`
+
+	// RevokedAt is set by RFC 7009 revocation (and by cascade when the
+	// associated refresh token is revoked).
+	RevokedAt *time.Time `sql:"index"`
 }
 
 // TableName specifies table name

--- a/oauth/authenticate.go
+++ b/oauth/authenticate.go
@@ -14,6 +14,9 @@ var (
 	ErrAccessTokenNotFound = errors.New("Access token not found")
 	// ErrAccessTokenExpired ...
 	ErrAccessTokenExpired = errors.New("Access token expired")
+	// ErrAccessTokenRevoked is returned when an access token has been
+	// revoked via RFC 7009 (or by cascade from a refresh-token revocation).
+	ErrAccessTokenRevoked = errors.New("Access token revoked")
 )
 
 // Authenticate checks the access token is valid
@@ -25,6 +28,11 @@ func (s *Service) Authenticate(token string) (*models.OauthAccessToken, error) {
 	// Not found
 	if notFound {
 		return nil, ErrAccessTokenNotFound
+	}
+
+	// Check the access token hasn't been revoked
+	if accessToken.RevokedAt != nil {
+		return nil, ErrAccessTokenRevoked
 	}
 
 	// Check the access token hasn't expired

--- a/oauth/errors.go
+++ b/oauth/errors.go
@@ -18,6 +18,7 @@ var (
 		ErrTokenMissing:                  http.StatusNotFound,
 		ErrTokenHintInvalid:              http.StatusBadRequest,
 		ErrAccessTokenNotFound:           http.StatusNotFound,
+		ErrAccessTokenRevoked:            http.StatusUnauthorized,
 		ErrRefreshTokenNotFound:          http.StatusNotFound,
 		ErrTokenMissing:                  http.StatusBadRequest,
 		ErrTokenHintInvalid:              http.StatusBadRequest,

--- a/oauth/revoke.go
+++ b/oauth/revoke.go
@@ -1,0 +1,225 @@
+package oauth
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/RichardKnop/go-oauth2-server/models"
+	"github.com/RichardKnop/go-oauth2-server/util/response"
+)
+
+// ErrUnsupportedTokenType is returned for an unrecognized token_type_hint.
+// RFC 7009 §2.2.1.
+var ErrUnsupportedTokenType = errors.New("unsupported_token_type")
+
+// revokeHandler implements POST /v1/oauth/revoke per RFC 7009.
+//
+// Per §2.2 the response is always 200 unless authentication fails or the
+// hint is malformed: unknown tokens, already-revoked tokens, and tokens
+// belonging to a different client are all silently swallowed.
+func (s *Service) revokeHandler(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		response.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	client, err := s.basicAuthClient(r)
+	if err != nil {
+		response.UnauthorizedError(w, err.Error())
+		return
+	}
+
+	token := r.Form.Get("token")
+	if token == "" {
+		// RFC 7009 doesn't strictly require this, but invalid_request is
+		// the standard response when a required parameter is missing.
+		response.Error(w, ErrTokenMissing.Error(), http.StatusBadRequest)
+		return
+	}
+
+	hint := r.Form.Get("token_type_hint")
+	switch hint {
+	case "", AccessTokenHint, RefreshTokenHint:
+		// fine
+	default:
+		response.Error(w, ErrUnsupportedTokenType.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := s.RevokeToken(token, hint, client); err != nil {
+		// Should not happen for the normal "not-found / wrong-client"
+		// paths — those return nil. A non-nil error here is a real DB or
+		// internal failure.
+		response.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// RevokeToken applies RFC 7009 revocation semantics. It looks up the token
+// (preferring `hint`'s table), checks ownership against `client`, and on a
+// match marks the token revoked. Refresh-token revocation cascades to all
+// non-revoked access tokens for the same (client_id, user_id) pair —
+// over-revoking slightly when a single user has multiple grants for the
+// same client, but correct in the common case and aligned with RFC 7009
+// §2.1's SHOULD on cascading.
+func (s *Service) RevokeToken(token, hint string, client *models.OauthClient) error {
+	// Try the hinted table first, then fall back to the other.
+	tryAccessFirst := hint != RefreshTokenHint
+
+	if tryAccessFirst {
+		if found, err := s.tryRevokeAccessToken(token, client); err != nil || found {
+			return err
+		}
+		_, err := s.tryRevokeRefreshToken(token, client)
+		return err
+	}
+
+	if found, err := s.tryRevokeRefreshToken(token, client); err != nil || found {
+		return err
+	}
+	_, err := s.tryRevokeAccessToken(token, client)
+	return err
+}
+
+func (s *Service) tryRevokeAccessToken(token string, client *models.OauthClient) (bool, error) {
+	at := new(models.OauthAccessToken)
+	notFound := s.db.Where("token = ?", token).First(at).RecordNotFound()
+	if notFound {
+		return false, nil
+	}
+	if at.ClientID.String != client.ID {
+		// Belongs to another client — RFC 7009 §2.2: silently OK.
+		return true, nil
+	}
+	if at.RevokedAt != nil {
+		return true, nil // already revoked; nothing to do
+	}
+	return true, s.markAccessTokenRevoked(at)
+}
+
+func (s *Service) tryRevokeRefreshToken(token string, client *models.OauthClient) (bool, error) {
+	rt := new(models.OauthRefreshToken)
+	notFound := s.db.Where("token = ?", token).First(rt).RecordNotFound()
+	if notFound {
+		return false, nil
+	}
+	if rt.ClientID.String != client.ID {
+		return true, nil
+	}
+	if rt.RevokedAt != nil {
+		return true, nil
+	}
+	return true, s.revokeRefreshTokenWithCascade(rt)
+}
+
+func (s *Service) markAccessTokenRevoked(at *models.OauthAccessToken) error {
+	now := time.Now().UTC()
+	return s.db.Model(at).Update("revoked_at", now).Error
+}
+
+// revokeRefreshTokenWithCascade marks the refresh token revoked and
+// cascades to every unrevoked access token for the same (client, user)
+// pair, in a single transaction.
+func (s *Service) revokeRefreshTokenWithCascade(rt *models.OauthRefreshToken) error {
+	now := time.Now().UTC()
+
+	tx := s.db.Begin()
+	if tx.Error != nil {
+		return tx.Error
+	}
+
+	if err := tx.Model(rt).Update("revoked_at", now).Error; err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	q := tx.Model(new(models.OauthAccessToken)).
+		Where("client_id = ?", rt.ClientID).
+		Where("revoked_at IS NULL")
+	if rt.UserID.Valid {
+		q = q.Where("user_id = ?", rt.UserID.String)
+	} else {
+		q = q.Where("user_id IS NULL")
+	}
+	if err := q.Update("revoked_at", now).Error; err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return tx.Commit().Error
+}
+
+// AdminRevokeByToken revokes a single token regardless of which client owns
+// it. Used by the test-mode /test/revoke endpoint. Returns true if a token
+// was found and revoked.
+func (s *Service) AdminRevokeByToken(token string) (bool, error) {
+	at := new(models.OauthAccessToken)
+	if !s.db.Where("token = ?", token).First(at).RecordNotFound() {
+		if at.RevokedAt != nil {
+			return true, nil
+		}
+		return true, s.markAccessTokenRevoked(at)
+	}
+	rt := new(models.OauthRefreshToken)
+	if !s.db.Where("token = ?", token).First(rt).RecordNotFound() {
+		if rt.RevokedAt != nil {
+			return true, nil
+		}
+		return true, s.revokeRefreshTokenWithCascade(rt)
+	}
+	return false, nil
+}
+
+// AdminRevokeByUser revokes all unrevoked tokens for the given user. Used
+// by /test/revoke. Returns the count of (refresh, access) tokens revoked.
+func (s *Service) AdminRevokeByUser(userID string) (int64, int64, error) {
+	now := time.Now().UTC()
+
+	tx := s.db.Begin()
+	if tx.Error != nil {
+		return 0, 0, tx.Error
+	}
+	rRes := tx.Model(new(models.OauthRefreshToken)).
+		Where("user_id = ? AND revoked_at IS NULL", userID).
+		Update("revoked_at", now)
+	if rRes.Error != nil {
+		tx.Rollback()
+		return 0, 0, rRes.Error
+	}
+	aRes := tx.Model(new(models.OauthAccessToken)).
+		Where("user_id = ? AND revoked_at IS NULL", userID).
+		Update("revoked_at", now)
+	if aRes.Error != nil {
+		tx.Rollback()
+		return 0, 0, aRes.Error
+	}
+	return rRes.RowsAffected, aRes.RowsAffected, tx.Commit().Error
+}
+
+// AdminRevokeByClient revokes all unrevoked tokens for the given client.
+func (s *Service) AdminRevokeByClient(clientID string) (int64, int64, error) {
+	now := time.Now().UTC()
+
+	tx := s.db.Begin()
+	if tx.Error != nil {
+		return 0, 0, tx.Error
+	}
+	rRes := tx.Model(new(models.OauthRefreshToken)).
+		Where("client_id = ? AND revoked_at IS NULL", clientID).
+		Update("revoked_at", now)
+	if rRes.Error != nil {
+		tx.Rollback()
+		return 0, 0, rRes.Error
+	}
+	aRes := tx.Model(new(models.OauthAccessToken)).
+		Where("client_id = ? AND revoked_at IS NULL", clientID).
+		Update("revoked_at", now)
+	if aRes.Error != nil {
+		tx.Rollback()
+		return 0, 0, aRes.Error
+	}
+	return rRes.RowsAffected, aRes.RowsAffected, tx.Commit().Error
+}

--- a/oauth/routes.go
+++ b/oauth/routes.go
@@ -10,6 +10,8 @@ const (
 	tokensPath         = "/" + tokensResource
 	introspectResource = "introspect"
 	introspectPath     = "/" + introspectResource
+	revokeResource     = "revoke"
+	revokePath         = "/" + revokeResource
 )
 
 // RegisterRoutes registers route handlers for the oauth service
@@ -32,6 +34,12 @@ func (s *Service) GetRoutes() []routes.Route {
 			Method:      "POST",
 			Pattern:     introspectPath,
 			HandlerFunc: s.introspectHandler,
+		},
+		{
+			Name:        "oauth_revoke",
+			Method:      "POST",
+			Pattern:     revokePath,
+			HandlerFunc: s.revokeHandler,
 		},
 	}
 }

--- a/oauth/service_interface.go
+++ b/oauth/service_interface.go
@@ -44,5 +44,9 @@ type ServiceInterface interface {
 	NewIntrospectResponseFromAccessToken(accessToken *models.OauthAccessToken) (*IntrospectResponse, error)
 	NewIntrospectResponseFromRefreshToken(refreshToken *models.OauthRefreshToken) (*IntrospectResponse, error)
 	ClearUserTokens(userSession *session.UserSession)
+	RevokeToken(token, hint string, client *models.OauthClient) error
+	AdminRevokeByToken(token string) (bool, error)
+	AdminRevokeByUser(userID string) (int64, int64, error)
+	AdminRevokeByClient(clientID string) (int64, int64, error)
 	Close()
 }

--- a/testmode/integration_test.go
+++ b/testmode/integration_test.go
@@ -783,6 +783,219 @@ func TestRefreshTokenRotation(t *testing.T) {
 	})
 }
 
+func TestTokenRevocation(t *testing.T) {
+	app := newTestApp(t, true)
+	srv := app.server
+
+	mustPostJSON(t, srv.URL+"/test/clients", map[string]string{
+		"key":          "rev-client",
+		"secret":       "rev-secret",
+		"redirect_uri": "https://x.example.com/cb",
+	})
+	mustPostJSON(t, srv.URL+"/test/clients", map[string]string{
+		"key":          "other-client",
+		"secret":       "other-secret",
+		"redirect_uri": "https://x.example.com/cb",
+	})
+	mustPostJSON(t, srv.URL+"/test/users", map[string]string{
+		"username": "frank@example.com",
+		"password": "hunter22",
+	})
+
+	passwordGrant := func(t *testing.T, clientKey, clientSecret string) (access, refresh string) {
+		t.Helper()
+		form := url.Values{}
+		form.Set("grant_type", "password")
+		form.Set("username", "frank@example.com")
+		form.Set("password", "hunter22")
+		form.Set("scope", "read")
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth(clientKey, clientSecret)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("password grant: %v", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		var tok struct {
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+		}
+		json.Unmarshal(body, &tok)
+		return tok.AccessToken, tok.RefreshToken
+	}
+
+	revoke := func(t *testing.T, clientKey, clientSecret, tok, hint string) (status int, body []byte) {
+		t.Helper()
+		form := url.Values{}
+		form.Set("token", tok)
+		if hint != "" {
+			form.Set("token_type_hint", hint)
+		}
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/revoke", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth(clientKey, clientSecret)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("revoke: %v", err)
+		}
+		body, _ = io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return resp.StatusCode, body
+	}
+
+	introspect := func(t *testing.T, clientKey, clientSecret, tok, hint string) (status int) {
+		t.Helper()
+		form := url.Values{}
+		form.Set("token", tok)
+		if hint != "" {
+			form.Set("token_type_hint", hint)
+		}
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/introspect", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth(clientKey, clientSecret)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("introspect: %v", err)
+		}
+		resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	t.Run("revoke access token then introspect returns invalid", func(t *testing.T) {
+		at, _ := passwordGrant(t, "rev-client", "rev-secret")
+		status, body := revoke(t, "rev-client", "rev-secret", at, "access_token")
+		if status != http.StatusOK {
+			t.Fatalf("revoke expected 200, got %d body=%s", status, body)
+		}
+		if introspect(t, "rev-client", "rev-secret", at, "access_token") == http.StatusOK {
+			t.Fatalf("introspect of revoked access token should not be 200")
+		}
+	})
+
+	t.Run("revoke refresh token also kills access tokens for the same user/client", func(t *testing.T) {
+		at, rt := passwordGrant(t, "rev-client", "rev-secret")
+		status, body := revoke(t, "rev-client", "rev-secret", rt, "refresh_token")
+		if status != http.StatusOK {
+			t.Fatalf("revoke expected 200, got %d body=%s", status, body)
+		}
+		// Refresh-grant with the revoked refresh token must fail.
+		form := url.Values{}
+		form.Set("grant_type", "refresh_token")
+		form.Set("refresh_token", rt)
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth("rev-client", "rev-secret")
+		resp, _ := http.DefaultClient.Do(req)
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			t.Fatalf("refresh of revoked RT should not succeed, got 200")
+		}
+		// Cascaded access token must also be invalid.
+		if introspect(t, "rev-client", "rev-secret", at, "access_token") == http.StatusOK {
+			t.Fatalf("cascaded access token should be invalid after refresh revocation")
+		}
+	})
+
+	t.Run("unknown token returns 200", func(t *testing.T) {
+		status, body := revoke(t, "rev-client", "rev-secret", "00000000-0000-0000-0000-000000000000", "")
+		if status != http.StatusOK {
+			t.Fatalf("expected 200 for unknown token, got %d body=%s", status, body)
+		}
+	})
+
+	t.Run("token belonging to other client returns 200 but is NOT revoked", func(t *testing.T) {
+		at, _ := passwordGrant(t, "other-client", "other-secret")
+		// rev-client tries to revoke other-client's access token.
+		status, _ := revoke(t, "rev-client", "rev-secret", at, "access_token")
+		if status != http.StatusOK {
+			t.Fatalf("expected 200 for cross-client revoke, got %d", status)
+		}
+		// Token should still work when its real owner introspects.
+		if introspect(t, "other-client", "other-secret", at, "access_token") != http.StatusOK {
+			t.Fatalf("token should still be valid for owning client")
+		}
+	})
+
+	t.Run("missing client auth returns 401", func(t *testing.T) {
+		form := url.Values{}
+		form.Set("token", "anything")
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/revoke", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		resp, _ := http.DefaultClient.Do(req)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", resp.StatusCode)
+		}
+		if got := resp.Header.Get("WWW-Authenticate"); got == "" {
+			t.Fatalf("expected WWW-Authenticate header on 401")
+		}
+	})
+
+	t.Run("unsupported token_type_hint returns 400", func(t *testing.T) {
+		status, _ := revoke(t, "rev-client", "rev-secret", "x", "bogus")
+		if status != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", status)
+		}
+	})
+
+	t.Run("/test/revoke by token bypasses ownership", func(t *testing.T) {
+		at, _ := passwordGrant(t, "other-client", "other-secret")
+		buf, _ := json.Marshal(map[string]string{"token": at})
+		resp, _ := http.Post(srv.URL+"/test/revoke", "application/json", bytes.NewReader(buf))
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("/test/revoke expected 200, got %d body=%s", resp.StatusCode, body)
+		}
+		var rr struct{ Found bool }
+		json.Unmarshal(body, &rr)
+		if !rr.Found {
+			t.Fatalf("expected found=true, got %s", body)
+		}
+		if introspect(t, "other-client", "other-secret", at, "access_token") == http.StatusOK {
+			t.Fatalf("token should be invalid after /test/revoke")
+		}
+	})
+
+	t.Run("/test/revoke by client_id (key) revokes everything for that client", func(t *testing.T) {
+		at, _ := passwordGrant(t, "other-client", "other-secret")
+		buf, _ := json.Marshal(map[string]string{"client_id": "other-client"})
+		resp, _ := http.Post(srv.URL+"/test/revoke", "application/json", bytes.NewReader(buf))
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("/test/revoke expected 200, got %d body=%s", resp.StatusCode, body)
+		}
+		if introspect(t, "other-client", "other-secret", at, "access_token") == http.StatusOK {
+			t.Fatalf("token should be invalid after client-wide revoke")
+		}
+	})
+
+	t.Run("revoke endpoint is recordable and scriptable", func(t *testing.T) {
+		// Script a 503 on the revoke endpoint.
+		buf, _ := json.Marshal(map[string]any{
+			"client_id": "rev-client",
+			"endpoint":  "revoke",
+			"actions":   []map[string]any{{"body_template": "temporarily_unavailable_503"}},
+		})
+		http.Post(srv.URL+"/test/scripts", "application/json", bytes.NewReader(buf))
+
+		status, _ := revoke(t, "rev-client", "rev-secret", "anything", "")
+		if status != http.StatusServiceUnavailable {
+			t.Fatalf("expected scripted 503, got %d", status)
+		}
+
+		// Real revoke calls (after queue empties) also show up in /test/requests.
+		revoke(t, "rev-client", "rev-secret", "x", "")
+		entries := app.recorder.Snapshot(testmode.SnapshotFilter{Endpoint: "revoke"})
+		if len(entries) == 0 {
+			t.Fatalf("expected at least one recorded revoke request")
+		}
+	})
+}
+
 func mustGet(t *testing.T, u string) *http.Response {
 	t.Helper()
 	resp, err := http.Get(u)

--- a/testmode/revoke.go
+++ b/testmode/revoke.go
@@ -1,0 +1,91 @@
+package testmode
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/RichardKnop/go-oauth2-server/util/response"
+)
+
+type adminRevokeRequest struct {
+	Token    string `json:"token,omitempty"`
+	UserID   string `json:"user_id,omitempty"`
+	ClientID string `json:"client_id,omitempty"`
+}
+
+type adminRevokeResponse struct {
+	Found          bool  `json:"found,omitempty"`
+	RefreshTokens  int64 `json:"refresh_tokens_revoked,omitempty"`
+	AccessTokens   int64 `json:"access_tokens_revoked,omitempty"`
+}
+
+// adminRevoke implements POST /test/revoke. It exists so a test harness can
+// simulate provider-side revocation without going through the production
+// /v1/oauth/revoke handler (no client auth, no ownership checks).
+//
+// Exactly one of token / user_id / client_id must be set.
+func (s *Service) adminRevoke(w http.ResponseWriter, r *http.Request) {
+	var req adminRevokeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		response.Error(w, "invalid JSON body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	set := 0
+	if req.Token != "" {
+		set++
+	}
+	if req.UserID != "" {
+		set++
+	}
+	if req.ClientID != "" {
+		set++
+	}
+	if set != 1 {
+		response.Error(w, "exactly one of token, user_id, client_id must be set", http.StatusBadRequest)
+		return
+	}
+
+	switch {
+	case req.Token != "":
+		found, err := s.oauthService.AdminRevokeByToken(req.Token)
+		if err != nil {
+			response.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		response.WriteJSON(w, adminRevokeResponse{Found: found}, http.StatusOK)
+	case req.UserID != "":
+		rt, at, err := s.oauthService.AdminRevokeByUser(req.UserID)
+		if err != nil {
+			response.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		response.WriteJSON(w, adminRevokeResponse{RefreshTokens: rt, AccessTokens: at}, http.StatusOK)
+	case req.ClientID != "":
+		// Client lookup: caller passes the client ID (UUID). For convenience
+		// we also accept the client key (the public identifier used for
+		// OAuth) and resolve it.
+		resolved, err := s.resolveClientID(req.ClientID)
+		if err != nil {
+			response.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		rt, at, err := s.oauthService.AdminRevokeByClient(resolved)
+		if err != nil {
+			response.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		response.WriteJSON(w, adminRevokeResponse{RefreshTokens: rt, AccessTokens: at}, http.StatusOK)
+	}
+}
+
+// resolveClientID accepts either a database ID (UUID) or the client's
+// public Key and returns the database ID.
+func (s *Service) resolveClientID(idOrKey string) (string, error) {
+	client, err := s.oauthService.FindClientByClientID(idOrKey)
+	if err == nil {
+		return client.ID, nil
+	}
+	// Not a key — assume it's already an ID.
+	return idOrKey, nil
+}

--- a/testmode/routes.go
+++ b/testmode/routes.go
@@ -68,5 +68,11 @@ func (s *Service) GetRoutes() []routes.Route {
 			Pattern:     "/refresh-tokens/rotate-policy",
 			HandlerFunc: s.rotatePolicy,
 		},
+		{
+			Name:        "test_admin_revoke",
+			Method:      "POST",
+			Pattern:     "/revoke",
+			HandlerFunc: s.adminRevoke,
+		},
 	}
 }


### PR DESCRIPTION
Closes #7. Tracking: #2.

## Summary

Implements RFC 7009 token revocation (`POST /v1/oauth/revoke`) plus a test-mode admin helper (`POST /test/revoke`) that bypasses ownership checks for harness-driven scenarios.

## Production endpoint: POST /v1/oauth/revoke

- Basic-auth client (same as `/v1/oauth/tokens`).
- Body: `token=<value>` and optional `token_type_hint=access_token|refresh_token`.
- Lookup uses the hinted table first, falls back to the other.
- Silently returns 200 on unknown / already-revoked / wrong-client tokens (§2.2).
- Revoking a refresh token cascades to all unrevoked access tokens for the same `(client_id, user_id)` — slight over-revocation when one user has multiple simultaneous grants for the same client, but aligned with RFC 7009 §2.1's SHOULD on cascading.
- 401 on missing/invalid client auth (with `WWW-Authenticate: Bearer realm=...`).
- 400 on unsupported `token_type_hint`.

## Schema

`migrate0003` adds `revoked_at *time.Time` to `oauth_access_tokens` via `AutoMigrate`. Additive, safe for existing prod data.

`Authenticate()` now rejects `RevokedAt != nil` with `ErrAccessTokenRevoked` → HTTP 401, so introspect and any future resource-server check immediately see revoked tokens as invalid.

## Test-mode endpoint: POST /test/revoke

Body is exactly one of:

- `{token: "..."}` — revoke that single token (access or refresh)
- `{user_id: "..."}` — revoke all unrevoked tokens for that user
- `{client_id: "..."}` — revoke all unrevoked tokens for that client; accepts either the client's public key or the database UUID

Returns `{found: bool}` for token mode, or `{refresh_tokens_revoked: N, access_tokens_revoked: M}` for the bulk modes.

## Wiring with prior PRs

`/v1/oauth/revoke` was already classified as the `revoke` endpoint in `classifyEndpoint` (added in PR-3). So:

- Request recording (PR-2): `GET /test/requests?endpoint=revoke` returns recorded revoke calls.
- Script queue (PR-3): `POST /test/scripts {endpoint: \"revoke\", ...}` injects responses.

Verified both in `revoke_endpoint_is_recordable_and_scriptable`.

## Acceptance criteria

- [x] Revoke an access token → introspect returns invalid
- [x] Revoke a refresh token → grant_type=refresh_token fails; cascaded access tokens are also invalid
- [x] Unknown token → 200
- [x] Token belonging to another client → 200, but token still works for the real owner
- [x] Missing client auth → 401 with `WWW-Authenticate`
- [x] Unsupported `token_type_hint` → 400
- [x] `/test/revoke` removes tokens with no client credentials
- [x] Scripting can inject failures into `/v1/oauth/revoke`

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./testmode/...` (9 new subtests for revocation + all prior subtests still green)
- [x] Live: revoke RT → introspect of derived AT returns 401 \"Access token revoked\"
- [ ] (Reviewer) verify production runserver path with the new endpoint against postgres