### PR TITLE
PR-6: Resource server stub (G7)

### DIFF
--- a/testmode/integration_test.go
+++ b/testmode/integration_test.go
@@ -996,6 +996,180 @@ func TestTokenRevocation(t *testing.T) {
 	})
 }
 
+func TestResourceServer(t *testing.T) {
+	app := newTestApp(t, true)
+	srv := app.server
+
+	mustPostJSON(t, srv.URL+"/test/clients", map[string]string{
+		"key":          "res-client",
+		"secret":       "res-secret",
+		"redirect_uri": "https://x.example.com/cb",
+	})
+	mustPostJSON(t, srv.URL+"/test/users", map[string]string{
+		"username": "grace@example.com",
+		"password": "hunter22",
+	})
+
+	getAccessToken := func(t *testing.T, scope string) string {
+		t.Helper()
+		form := url.Values{}
+		form.Set("grant_type", "password")
+		form.Set("username", "grace@example.com")
+		form.Set("password", "hunter22")
+		form.Set("scope", scope)
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth("res-client", "res-secret")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("token: %v", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		var tok struct{ AccessToken string `json:"access_token"` }
+		json.Unmarshal(body, &tok)
+		if tok.AccessToken == "" {
+			t.Fatalf("no access token: %s", body)
+		}
+		return tok.AccessToken
+	}
+
+	getResource := func(t *testing.T, path, token string) (int, http.Header, []byte) {
+		t.Helper()
+		req, _ := http.NewRequest("GET", srv.URL+path, nil)
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("get resource: %v", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return resp.StatusCode, resp.Header, body
+	}
+
+	t.Run("valid bearer token returns default 200 body", func(t *testing.T) {
+		at := getAccessToken(t, "read")
+		status, _, body := getResource(t, "/test/resource/foo", at)
+		if status != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", status, body)
+		}
+		var doc map[string]any
+		json.Unmarshal(body, &doc)
+		if doc["path"] != "/test/resource/foo" {
+			t.Fatalf("expected path field, got %v", doc)
+		}
+		if doc["scope"] != "read" {
+			t.Fatalf("expected scope=read, got %v", doc)
+		}
+		if doc["client_id"] == nil || doc["client_id"] == "" {
+			t.Fatalf("expected client_id, got %v", doc)
+		}
+	})
+
+	t.Run("missing Authorization returns 401 with WWW-Authenticate", func(t *testing.T) {
+		status, hdr, _ := getResource(t, "/test/resource/foo", "")
+		if status != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", status)
+		}
+		if got := hdr.Get("WWW-Authenticate"); !strings.Contains(got, `error="invalid_token"`) {
+			t.Fatalf("expected invalid_token in WWW-Authenticate, got %q", got)
+		}
+	})
+
+	t.Run("revoked access token returns 401", func(t *testing.T) {
+		at := getAccessToken(t, "read")
+		// Revoke via the test-mode admin endpoint.
+		buf, _ := json.Marshal(map[string]string{"token": at})
+		http.Post(srv.URL+"/test/revoke", "application/json", bytes.NewReader(buf))
+
+		status, _, _ := getResource(t, "/test/resource/foo", at)
+		if status != http.StatusUnauthorized {
+			t.Fatalf("expected 401 for revoked token, got %d", status)
+		}
+	})
+
+	t.Run("scope policy enforces required scope", func(t *testing.T) {
+		// Register: /test/resource/admin requires read_write
+		buf, _ := json.Marshal(map[string]string{
+			"path":           "/test/resource/admin",
+			"required_scope": "read_write",
+		})
+		resp, _ := http.Post(srv.URL+"/test/resource-policy", "application/json", bytes.NewReader(buf))
+		resp.Body.Close()
+
+		// read-only token gets 403
+		atRead := getAccessToken(t, "read")
+		status, hdr, body := getResource(t, "/test/resource/admin", atRead)
+		if status != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d body=%s", status, body)
+		}
+		if got := hdr.Get("WWW-Authenticate"); !strings.Contains(got, `error="insufficient_scope"`) {
+			t.Fatalf("expected insufficient_scope, got %q", got)
+		}
+		if got := hdr.Get("WWW-Authenticate"); !strings.Contains(got, `scope="read_write"`) {
+			t.Fatalf("expected scope= in WWW-Authenticate, got %q", got)
+		}
+
+		// read_write token passes
+		atRW := getAccessToken(t, "read_write")
+		status2, _, body2 := getResource(t, "/test/resource/admin", atRW)
+		if status2 != http.StatusOK {
+			t.Fatalf("expected 200 for read_write, got %d body=%s", status2, body2)
+		}
+	})
+
+	t.Run("script queue intercepts resource calls", func(t *testing.T) {
+		at := getAccessToken(t, "read")
+		buf, _ := json.Marshal(map[string]any{
+			"endpoint": "resource",
+			"actions":  []map[string]any{{"status": 500, "body": `{"e":"bad"}`}},
+		})
+		http.Post(srv.URL+"/test/scripts", "application/json", bytes.NewReader(buf))
+
+		status, _, body := getResource(t, "/test/resource/foo", at)
+		if status != 500 {
+			t.Fatalf("expected scripted 500, got %d body=%s", status, body)
+		}
+		if !strings.Contains(string(body), "bad") {
+			t.Fatalf("expected scripted body, got %s", body)
+		}
+	})
+
+	t.Run("resource calls are recorded", func(t *testing.T) {
+		app.recorder.Reset()
+		at := getAccessToken(t, "read")
+		getResource(t, "/test/resource/inspect-me", at)
+
+		entries := app.recorder.Snapshot(testmode.SnapshotFilter{Endpoint: "resource"})
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 recorded resource request, got %d", len(entries))
+		}
+		e := entries[0]
+		if e.Path != "/test/resource/inspect-me" {
+			t.Fatalf("expected path /test/resource/inspect-me, got %q", e.Path)
+		}
+		if got := e.Headers["Authorization"]; got != "Bearer <redacted>" {
+			t.Fatalf("expected Bearer <redacted>, got %q", got)
+		}
+	})
+
+	t.Run("/test/resource-policy is not classified as a resource call", func(t *testing.T) {
+		app.recorder.Reset()
+		buf, _ := json.Marshal(map[string]string{
+			"path":           "/test/resource/x",
+			"required_scope": "",
+		})
+		resp, _ := http.Post(srv.URL+"/test/resource-policy", "application/json", bytes.NewReader(buf))
+		resp.Body.Close()
+		entries := app.recorder.Snapshot(testmode.SnapshotFilter{Endpoint: "resource"})
+		if len(entries) != 0 {
+			t.Fatalf("/test/resource-policy should not be recorded as resource: %v", entries)
+		}
+	})
+}
+
 func mustGet(t *testing.T, u string) *http.Response {
 	t.Helper()
 	resp, err := http.Get(u)

--- a/testmode/recorder.go
+++ b/testmode/recorder.go
@@ -105,7 +105,7 @@ func classifyEndpoint(path string, form url.Values) string {
 		return "introspect"
 	case path == "/v1/oauth/revoke":
 		return "revoke"
-	case strings.HasPrefix(path, "/test/resource"):
+	case path == "/test/resource" || strings.HasPrefix(path, "/test/resource/"):
 		return "resource"
 	default:
 		return ""

--- a/testmode/resource.go
+++ b/testmode/resource.go
@@ -1,0 +1,158 @@
+package testmode
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/RichardKnop/go-oauth2-server/util/response"
+)
+
+// resourcePolicies holds registered scope requirements keyed by exact path
+// (e.g. "/test/resource/admin"). Tests register entries via
+// POST /test/resource-policy.
+type resourcePolicies struct {
+	mu    sync.RWMutex
+	rules map[string]string // path -> required scope (space-separated)
+}
+
+func newResourcePolicies() *resourcePolicies {
+	return &resourcePolicies{rules: make(map[string]string)}
+}
+
+func (p *resourcePolicies) set(path, scope string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.rules[path] = scope
+}
+
+func (p *resourcePolicies) get(path string) (string, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	s, ok := p.rules[path]
+	return s, ok
+}
+
+func (p *resourcePolicies) clear() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.rules = make(map[string]string)
+}
+
+// resourceHandler implements ANY /test/resource/{path}. The script
+// middleware runs first, so by the time we get here any queued action has
+// either replaced the response or fallen through.
+//
+// Auth: Bearer token in Authorization header. Token must be a valid
+// (unexpired, unrevoked) access token. Returns 401 invalid_token otherwise.
+//
+// Scope: if a policy is registered for this path, every required scope
+// must be present in the token's scopes. Mismatch returns 403
+// insufficient_scope.
+//
+// Default body: 200 with {sub, client_id, scope, path}. The recorder
+// captures the inbound request automatically.
+func (s *Service) resourceHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		writeBearerError(w, http.StatusUnauthorized, "invalid_token", "missing Authorization header", "")
+		return
+	}
+	parts := strings.SplitN(auth, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") || parts[1] == "" {
+		writeBearerError(w, http.StatusUnauthorized, "invalid_token", "Authorization header must be 'Bearer <token>'", "")
+		return
+	}
+
+	accessToken, err := s.oauthService.Authenticate(parts[1])
+	if err != nil {
+		writeBearerError(w, http.StatusUnauthorized, "invalid_token", err.Error(), "")
+		return
+	}
+
+	if required, ok := s.resourcePolicies.get(r.URL.Path); ok {
+		if !hasAllScopes(accessToken.Scope, required) {
+			writeBearerError(w, http.StatusForbidden, "insufficient_scope", "token does not have required scope(s)", required)
+			return
+		}
+	}
+
+	body := map[string]any{
+		"sub":       accessToken.UserID.String,
+		"client_id": accessToken.ClientID.String,
+		"scope":     accessToken.Scope,
+		"path":      r.URL.Path,
+	}
+	if r.Method != http.MethodGet && r.Method != "" {
+		body["method"] = r.Method
+	}
+	response.WriteJSON(w, body, http.StatusOK)
+}
+
+// resourcePolicyRequest is the body of POST /test/resource-policy.
+type resourcePolicyRequest struct {
+	Path          string `json:"path"`
+	RequiredScope string `json:"required_scope"`
+}
+
+// resourcePolicyHandler implements POST /test/resource-policy.
+func (s *Service) resourcePolicyHandler(w http.ResponseWriter, r *http.Request) {
+	var req resourcePolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		response.Error(w, "invalid JSON body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Path == "" {
+		response.Error(w, "path is required", http.StatusBadRequest)
+		return
+	}
+	if !strings.HasPrefix(req.Path, "/test/resource/") {
+		response.Error(w, "path must start with /test/resource/", http.StatusBadRequest)
+		return
+	}
+	s.resourcePolicies.set(req.Path, req.RequiredScope)
+	response.NoContent(w)
+}
+
+// hasAllScopes reports whether every space-separated scope in `required`
+// is also present in `granted`.
+func hasAllScopes(granted, required string) bool {
+	if required == "" {
+		return true
+	}
+	grantedSet := make(map[string]struct{})
+	for _, s := range strings.Fields(granted) {
+		grantedSet[s] = struct{}{}
+	}
+	for _, want := range strings.Fields(required) {
+		if _, ok := grantedSet[want]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// writeBearerError writes an RFC 6750 §3 WWW-Authenticate response.
+func writeBearerError(w http.ResponseWriter, status int, code, description, scope string) {
+	parts := []string{`realm="test"`}
+	if code != "" {
+		parts = append(parts, fmt.Sprintf(`error="%s"`, code))
+	}
+	if description != "" {
+		parts = append(parts, fmt.Sprintf(`error_description="%s"`, sanitizeHeaderValue(description)))
+	}
+	if scope != "" {
+		parts = append(parts, fmt.Sprintf(`scope="%s"`, scope))
+	}
+	w.Header().Set("WWW-Authenticate", "Bearer "+strings.Join(parts, ", "))
+	response.Error(w, code, status)
+}
+
+// sanitizeHeaderValue strips characters that would break the
+// WWW-Authenticate quoted-string. Test-mode only; cheap and safe.
+func sanitizeHeaderValue(s string) string {
+	r := strings.NewReplacer(`"`, `'`, "\r", " ", "\n", " ")
+	return r.Replace(s)
+}

--- a/testmode/routes.go
+++ b/testmode/routes.go
@@ -9,6 +9,10 @@ import (
 func (s *Service) RegisterRoutes(router *mux.Router, prefix string) {
 	subRouter := router.PathPrefix(prefix).Subrouter()
 	routes.AddRoutes(s.GetRoutes(), subRouter)
+
+	// /resource/* is a catch-all that matches any HTTP method, so it can't
+	// fit through routes.AddRoutes (which is method-specific).
+	subRouter.PathPrefix("/resource/").HandlerFunc(s.resourceHandler)
 }
 
 // GetRoutes returns the routes exposed by the test-mode control plane.
@@ -73,6 +77,12 @@ func (s *Service) GetRoutes() []routes.Route {
 			Method:      "POST",
 			Pattern:     "/revoke",
 			HandlerFunc: s.adminRevoke,
+		},
+		{
+			Name:        "test_resource_policy",
+			Method:      "POST",
+			Pattern:     "/resource-policy",
+			HandlerFunc: s.resourcePolicyHandler,
 		},
 	}
 }

--- a/testmode/service.go
+++ b/testmode/service.go
@@ -8,21 +8,23 @@ import (
 
 // Service holds dependencies for the test-mode control plane.
 type Service struct {
-	cnf          *config.Config
-	db           *gorm.DB
-	oauthService oauth.ServiceInterface
-	recorder     *Recorder
-	queue        *ScriptQueue
+	cnf              *config.Config
+	db               *gorm.DB
+	oauthService     oauth.ServiceInterface
+	recorder         *Recorder
+	queue            *ScriptQueue
+	resourcePolicies *resourcePolicies
 }
 
 // NewService constructs a test-mode service.
 func NewService(cnf *config.Config, db *gorm.DB, oauthService oauth.ServiceInterface) *Service {
 	return &Service{
-		cnf:          cnf,
-		db:           db,
-		oauthService: oauthService,
-		recorder:     NewRecorder(0),
-		queue:        NewScriptQueue(),
+		cnf:              cnf,
+		db:               db,
+		oauthService:     oauthService,
+		recorder:         NewRecorder(0),
+		queue:            NewScriptQueue(),
+		resourcePolicies: newResourcePolicies(),
 	}
 }
 


### PR DESCRIPTION
Closes #8. Tracking: #2.

## Summary

`ANY /test/resource/{path}` is a fake protected resource the proxy can call with an access token. It validates the bearer, returns a default body, and supports per-path scope policy. Test-mode only.

## Behavior

1. Extract `Authorization: Bearer <token>`. Missing/malformed → `401 invalid_token` with `WWW-Authenticate: Bearer realm=\"test\", error=\"invalid_token\", ...`.
2. `oauth.Authenticate(token)` validates the token (rejects expired/revoked from PRs 4 & 5). On error → `401 invalid_token`.
3. If a scope policy is registered for this path, every required scope must be present in the token's scopes. Mismatch → `403 insufficient_scope` with `WWW-Authenticate: Bearer ..., error=\"insufficient_scope\", scope=\"<required>\"`.
4. Otherwise → `200 {sub, client_id, scope, path}`.

## API

`POST /test/resource-policy` registers a scope requirement:

```json
{"path": "/test/resource/admin", "required_scope": "read_write"}
```

Exact-path match (no prefix matching). Multi-scope is supported via a space-separated string.

## Wiring with prior PRs

Already wired via `classifyEndpoint`, so:

- **Script queue (PR-3)**: `POST /test/scripts {endpoint: \"resource\", ...}` injects responses (status, body, drop, delay) ahead of the handler.
- **Request recording (PR-2)**: `GET /test/requests?endpoint=resource` returns the recorded calls with `Authorization: Bearer <redacted>`.
- **Revocation (PR-5)**: revoked access tokens return 401 from the resource handler immediately.

I tightened `classifyEndpoint` from `HasPrefix(\"/test/resource\")` to require the trailing slash so `/test/resource-policy` is not classified as a resource call.

## Routing note

Mux's standard `routes.AddRoutes` helper is method-specific. The catch-all is registered directly via `subRouter.PathPrefix(\"/resource/\").HandlerFunc(...)` so any HTTP method matches.

## Acceptance criteria

- [x] Token via real flow → `/test/resource/foo` → 200 default body
- [x] Expired/revoked token → 401
- [x] Scripted 500 returns 500 on next call
- [x] Registered scope requirement is enforced (403 with correct WWW-Authenticate)
- [x] Resource calls are recorded with `Authorization: Bearer <redacted>`
- [x] `/test/resource-policy` itself is not classified as a resource call

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./testmode/...` — 7 new subtests + everything from prior PRs still green
- [x] Live: 200 with body, 401 with proper WWW-Authenticate, scope policy 403 with `scope=\"read_write\"`, scripted 500
- [ ] (Reviewer) confirm production runserver path is unaffected (no `/test/*` routes mounted)