### PR TITLE
PR-8: Auth method compatibility (G10)

### DIFF
--- a/models/migrations.go
+++ b/models/migrations.go
@@ -25,6 +25,10 @@ var (
 			Name:     "pkce_challenge",
 			Function: migrate0004,
 		},
+		{
+			Name:     "client_auth_method",
+			Function: migrate0005,
+		},
 	}
 )
 
@@ -154,6 +158,15 @@ func migrate0003(db *gorm.DB, name string) error {
 func migrate0004(db *gorm.DB, name string) error {
 	if err := db.AutoMigrate(new(OauthAuthorizationCode)).Error; err != nil {
 		return fmt.Errorf("Error adding PKCE columns: %s", err)
+	}
+	return nil
+}
+
+// migrate0005 adds token_endpoint_auth_method to oauth_clients. Default
+// 'client_secret_basic' so existing rows behave exactly as before.
+func migrate0005(db *gorm.DB, name string) error {
+	if err := db.AutoMigrate(new(OauthClient)).Error; err != nil {
+		return fmt.Errorf("Error adding token_endpoint_auth_method column: %s", err)
 	}
 	return nil
 }

--- a/models/oauth.go
+++ b/models/oauth.go
@@ -15,6 +15,12 @@ type OauthClient struct {
 	Key         string         `sql:"type:varchar(254);unique;not null"`
 	Secret      string         `sql:"type:varchar(60);not null"`
 	RedirectURI sql.NullString `sql:"type:varchar(200)"`
+
+	// TokenEndpointAuthMethod is one of "client_secret_basic" (default),
+	// "client_secret_post", or "none" (public clients with PKCE).
+	// Empty string is treated as the default for backwards compatibility
+	// with rows created before this column existed.
+	TokenEndpointAuthMethod string `sql:"type:varchar(32);default:'client_secret_basic'"`
 }
 
 // TableName specifies table name

--- a/oauth/auth_methods.go
+++ b/oauth/auth_methods.go
@@ -1,0 +1,109 @@
+package oauth
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/RichardKnop/go-oauth2-server/models"
+	"github.com/RichardKnop/go-oauth2-server/util/password"
+)
+
+// Token-endpoint client authentication methods (RFC 7591 §2).
+const (
+	AuthMethodSecretBasic = "client_secret_basic"
+	AuthMethodSecretPost  = "client_secret_post"
+	AuthMethodNone        = "none"
+)
+
+// ValidAuthMethod reports whether m is one of the supported method names.
+// Empty string is also valid and is treated as the default
+// (client_secret_basic).
+func ValidAuthMethod(m string) bool {
+	switch m {
+	case "", AuthMethodSecretBasic, AuthMethodSecretPost, AuthMethodNone:
+		return true
+	}
+	return false
+}
+
+// ErrPublicClientRequiresPKCE is returned when GrantAuthorizationCode is
+// called for a `none` client without a code_challenge.
+var ErrPublicClientRequiresPKCE = errors.New("public clients (token_endpoint_auth_method=none) must use PKCE")
+
+// authenticateClient resolves and authenticates the client for token,
+// introspect, and revoke endpoints, applying the per-client
+// token_endpoint_auth_method:
+//
+//   - client_secret_basic: HTTP Basic; reject form client_id/client_secret
+//   - client_secret_post:  form client_id+client_secret; reject Basic
+//   - none:                form client_id only; reject Basic and form secret.
+//                          PKCE on the authorization_code grant is enforced
+//                          at GrantAuthorizationCode time.
+//
+// Mismatches return ErrInvalidClientIDOrSecret which the handler maps to
+// 401. Empty TokenEndpointAuthMethod on the client record is treated as
+// client_secret_basic for backwards compatibility.
+func (s *Service) authenticateClient(r *http.Request) (*models.OauthClient, error) {
+	basicID, basicSecret, hasBasic := r.BasicAuth()
+	formID := r.Form.Get("client_id")
+	formSecret := r.Form.Get("client_secret")
+
+	var clientID string
+	switch {
+	case hasBasic && basicID != "":
+		clientID = basicID
+	case formID != "":
+		clientID = formID
+	default:
+		return nil, ErrInvalidClientIDOrSecret
+	}
+
+	client, err := s.FindClientByClientID(clientID)
+	if err != nil {
+		return nil, ErrInvalidClientIDOrSecret
+	}
+
+	method := client.TokenEndpointAuthMethod
+	if method == "" {
+		method = AuthMethodSecretBasic
+	}
+
+	switch method {
+	case AuthMethodSecretBasic:
+		if !hasBasic {
+			return nil, ErrInvalidClientIDOrSecret
+		}
+		if formID != "" || formSecret != "" {
+			return nil, ErrInvalidClientIDOrSecret
+		}
+		if password.VerifyPassword(client.Secret, basicSecret) != nil {
+			return nil, ErrInvalidClientIDOrSecret
+		}
+	case AuthMethodSecretPost:
+		if hasBasic {
+			return nil, ErrInvalidClientIDOrSecret
+		}
+		if formID == "" || formSecret == "" {
+			return nil, ErrInvalidClientIDOrSecret
+		}
+		if password.VerifyPassword(client.Secret, formSecret) != nil {
+			return nil, ErrInvalidClientIDOrSecret
+		}
+	case AuthMethodNone:
+		if hasBasic {
+			return nil, ErrInvalidClientIDOrSecret
+		}
+		if formSecret != "" {
+			return nil, ErrInvalidClientIDOrSecret
+		}
+		if formID == "" {
+			return nil, ErrInvalidClientIDOrSecret
+		}
+		// PKCE enforcement is at the authorize step + verifier check; no
+		// extra work required here.
+	default:
+		return nil, ErrInvalidClientIDOrSecret
+	}
+
+	return client, nil
+}

--- a/oauth/authorization_code.go
+++ b/oauth/authorization_code.go
@@ -18,7 +18,15 @@ var (
 // GrantAuthorizationCode grants a new authorization code. codeChallenge
 // and codeChallengeMethod implement RFC 7636 PKCE; both empty means the
 // request did not opt into PKCE.
+//
+// Public clients (token_endpoint_auth_method=none) MUST use PKCE — the
+// code_challenge is required and the call fails with
+// ErrPublicClientRequiresPKCE if absent.
 func (s *Service) GrantAuthorizationCode(client *models.OauthClient, user *models.OauthUser, expiresIn int, redirectURI, scope, codeChallenge, codeChallengeMethod string) (*models.OauthAuthorizationCode, error) {
+	if client.TokenEndpointAuthMethod == AuthMethodNone && codeChallenge == "" {
+		return nil, ErrPublicClientRequiresPKCE
+	}
+
 	resolvedMethod, err := validateChallengeAtAuthorize(codeChallenge, codeChallengeMethod)
 	if err != nil {
 		return nil, err

--- a/oauth/client.go
+++ b/oauth/client.go
@@ -19,6 +19,9 @@ var (
 	ErrInvalidClientSecret = errors.New("Invalid client secret")
 	// ErrClientIDTaken ...
 	ErrClientIDTaken = errors.New("Client ID taken")
+	// ErrInvalidAuthMethod is returned by CreateClient when an unknown
+	// token_endpoint_auth_method is supplied.
+	ErrInvalidAuthMethod = errors.New("Invalid token_endpoint_auth_method")
 )
 
 // ClientExists returns true if client exists
@@ -42,14 +45,16 @@ func (s *Service) FindClientByClientID(clientID string) (*models.OauthClient, er
 	return client, nil
 }
 
-// CreateClient saves a new client to database
-func (s *Service) CreateClient(clientID, secret, redirectURI string) (*models.OauthClient, error) {
-	return s.createClientCommon(s.db, clientID, secret, redirectURI)
+// CreateClient saves a new client to database. tokenEndpointAuthMethod
+// must be one of "client_secret_basic" (default), "client_secret_post",
+// "none", or empty (treated as the default).
+func (s *Service) CreateClient(clientID, secret, redirectURI, tokenEndpointAuthMethod string) (*models.OauthClient, error) {
+	return s.createClientCommon(s.db, clientID, secret, redirectURI, tokenEndpointAuthMethod)
 }
 
-// CreateClientTx saves a new client to database using injected db object
-func (s *Service) CreateClientTx(tx *gorm.DB, clientID, secret, redirectURI string) (*models.OauthClient, error) {
-	return s.createClientCommon(tx, clientID, secret, redirectURI)
+// CreateClientTx saves a new client to database using injected db object.
+func (s *Service) CreateClientTx(tx *gorm.DB, clientID, secret, redirectURI, tokenEndpointAuthMethod string) (*models.OauthClient, error) {
+	return s.createClientCommon(tx, clientID, secret, redirectURI, tokenEndpointAuthMethod)
 }
 
 // AuthClient authenticates client
@@ -68,16 +73,29 @@ func (s *Service) AuthClient(clientID, secret string) (*models.OauthClient, erro
 	return client, nil
 }
 
-func (s *Service) createClientCommon(db *gorm.DB, clientID, secret, redirectURI string) (*models.OauthClient, error) {
+func (s *Service) createClientCommon(db *gorm.DB, clientID, secret, redirectURI, tokenEndpointAuthMethod string) (*models.OauthClient, error) {
 	// Check client ID
 	if s.ClientExists(clientID) {
 		return nil, ErrClientIDTaken
 	}
 
-	// Hash password
-	secretHash, err := password.HashPassword(secret)
-	if err != nil {
-		return nil, err
+	if !ValidAuthMethod(tokenEndpointAuthMethod) {
+		return nil, ErrInvalidAuthMethod
+	}
+	method := tokenEndpointAuthMethod
+	if method == "" {
+		method = AuthMethodSecretBasic
+	}
+
+	// `none` clients have no secret; for the other methods we hash whatever
+	// secret was provided (empty string is allowed but won't authenticate).
+	var secretHash []byte
+	if method != AuthMethodNone {
+		var err error
+		secretHash, err = password.HashPassword(secret)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	client := &models.OauthClient{
@@ -85,9 +103,10 @@ func (s *Service) createClientCommon(db *gorm.DB, clientID, secret, redirectURI 
 			ID:        uuid.New(),
 			CreatedAt: time.Now().UTC(),
 		},
-		Key:         strings.ToLower(clientID),
-		Secret:      string(secretHash),
-		RedirectURI: util.StringOrNull(redirectURI),
+		Key:                     strings.ToLower(clientID),
+		Secret:                  string(secretHash),
+		RedirectURI:             util.StringOrNull(redirectURI),
+		TokenEndpointAuthMethod: method,
 	}
 	if err := db.Create(client).Error; err != nil {
 		return nil, err

--- a/oauth/client_test.go
+++ b/oauth/client_test.go
@@ -46,6 +46,7 @@ func (suite *OauthTestSuite) TestCreateClient() {
 		"test_client_1",           // client ID
 		"test_secret",             // secret
 		"https://www.example.com", // redirect URI
+		"",                        // token_endpoint_auth_method (default)
 	)
 
 	// Client object should be nil
@@ -61,6 +62,7 @@ func (suite *OauthTestSuite) TestCreateClient() {
 		"test_client_3",           // client ID
 		"test_secret",             // secret
 		"https://www.example.com", // redirect URI
+		"",                        // token_endpoint_auth_method (default)
 	)
 
 	// Error should be nil

--- a/oauth/handlers.go
+++ b/oauth/handlers.go
@@ -39,8 +39,8 @@ func (s *Service) tokensHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Client auth
-	client, err := s.basicAuthClient(r)
+	// Client auth (per-client method: basic, post, or none)
+	client, err := s.authenticateClient(r)
 	if err != nil {
 		response.UnauthorizedError(w, err.Error())
 		return
@@ -60,8 +60,12 @@ func (s *Service) tokensHandler(w http.ResponseWriter, r *http.Request) {
 // introspectHandler handles OAuth 2.0 introspect request
 // (POST /v1/oauth/introspect)
 func (s *Service) introspectHandler(w http.ResponseWriter, r *http.Request) {
-	// Client auth
-	client, err := s.basicAuthClient(r)
+	if err := r.ParseForm(); err != nil {
+		response.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// Client auth (per-client method: basic, post, or none)
+	client, err := s.authenticateClient(r)
 	if err != nil {
 		response.UnauthorizedError(w, err.Error())
 		return
@@ -78,20 +82,3 @@ func (s *Service) introspectHandler(w http.ResponseWriter, r *http.Request) {
 	response.WriteJSON(w, resp, 200)
 }
 
-// Get client credentials from basic auth and try to authenticate client
-func (s *Service) basicAuthClient(r *http.Request) (*models.OauthClient, error) {
-	// Get client credentials from basic auth
-	clientID, secret, ok := r.BasicAuth()
-	if !ok {
-		return nil, ErrInvalidClientIDOrSecret
-	}
-
-	// Authenticate the client
-	client, err := s.AuthClient(clientID, secret)
-	if err != nil {
-		// For security reasons, return a general error message
-		return nil, ErrInvalidClientIDOrSecret
-	}
-
-	return client, nil
-}

--- a/oauth/revoke.go
+++ b/oauth/revoke.go
@@ -24,7 +24,7 @@ func (s *Service) revokeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client, err := s.basicAuthClient(r)
+	client, err := s.authenticateClient(r)
 	if err != nil {
 		response.UnauthorizedError(w, err.Error())
 		return

--- a/oauth/service_interface.go
+++ b/oauth/service_interface.go
@@ -20,8 +20,8 @@ type ServiceInterface interface {
 	RegisterRoutes(router *mux.Router, prefix string)
 	ClientExists(clientID string) bool
 	FindClientByClientID(clientID string) (*models.OauthClient, error)
-	CreateClient(clientID, secret, redirectURI string) (*models.OauthClient, error)
-	CreateClientTx(tx *gorm.DB, clientID, secret, redirectURI string) (*models.OauthClient, error)
+	CreateClient(clientID, secret, redirectURI, tokenEndpointAuthMethod string) (*models.OauthClient, error)
+	CreateClientTx(tx *gorm.DB, clientID, secret, redirectURI, tokenEndpointAuthMethod string) (*models.OauthClient, error)
 	AuthClient(clientID, secret string) (*models.OauthClient, error)
 	UserExists(username string) bool
 	FindUserByUsername(username string) (*models.OauthUser, error)

--- a/testmode/handlers.go
+++ b/testmode/handlers.go
@@ -20,9 +20,10 @@ type createClientRequest struct {
 }
 
 type clientResponse struct {
-	ID          string `json:"id"`
-	Key         string `json:"key"`
-	RedirectURI string `json:"redirect_uri,omitempty"`
+	ID                      string `json:"id"`
+	Key                     string `json:"key"`
+	RedirectURI             string `json:"redirect_uri,omitempty"`
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`
 }
 
 func (s *Service) createClient(w http.ResponseWriter, r *http.Request) {
@@ -35,22 +36,22 @@ func (s *Service) createClient(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, "key is required", http.StatusBadRequest)
 		return
 	}
-	if req.Scope != "" || req.TokenEndpointAuthMethod != "" {
-		log.INFO.Printf("testmode: /test/clients received scope=%q token_endpoint_auth_method=%q "+
-			"(accepted but not yet enforced; see PR-3, PR-8)",
-			req.Scope, req.TokenEndpointAuthMethod)
+	if req.Scope != "" {
+		log.INFO.Printf("testmode: /test/clients received scope=%q (accepted but not yet enforced; see PR-3)",
+			req.Scope)
 	}
 
-	client, err := s.oauthService.CreateClient(req.Key, req.Secret, req.RedirectURI)
+	client, err := s.oauthService.CreateClient(req.Key, req.Secret, req.RedirectURI, req.TokenEndpointAuthMethod)
 	if err != nil {
 		response.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	response.WriteJSON(w, clientResponse{
-		ID:          client.ID,
-		Key:         client.Key,
-		RedirectURI: client.RedirectURI.String,
+		ID:                      client.ID,
+		Key:                     client.Key,
+		RedirectURI:             client.RedirectURI.String,
+		TokenEndpointAuthMethod: client.TokenEndpointAuthMethod,
 	}, http.StatusCreated)
 }
 

--- a/testmode/integration_test.go
+++ b/testmode/integration_test.go
@@ -1387,6 +1387,230 @@ func TestPKCE(t *testing.T) {
 	})
 }
 
+func TestAuthMethodCompatibility(t *testing.T) {
+	app := newTestApp(t, true)
+	srv := app.server
+
+	registerClient := func(t *testing.T, key, secret, method string) {
+		t.Helper()
+		body := map[string]string{
+			"key":          key,
+			"redirect_uri": "https://app.example.com/cb",
+			"token_endpoint_auth_method": method,
+		}
+		if secret != "" {
+			body["secret"] = secret
+		}
+		mustPostJSON(t, srv.URL+"/test/clients", body)
+	}
+
+	tokenCall := func(t *testing.T, basicUser, basicPass string, form url.Values) (int, []byte) {
+		t.Helper()
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		if basicUser != "" {
+			req.SetBasicAuth(basicUser, basicPass)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("token: %v", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return resp.StatusCode, body
+	}
+
+	t.Run("client_secret_basic: basic works, post rejected", func(t *testing.T) {
+		registerClient(t, "basic-c", "basic-s", "client_secret_basic")
+		// Basic OK
+		form := url.Values{}
+		form.Set("grant_type", "client_credentials")
+		form.Set("scope", "read")
+		status, _ := tokenCall(t, "basic-c", "basic-s", form)
+		if status != http.StatusOK {
+			t.Fatalf("basic auth on basic client expected 200, got %d", status)
+		}
+		// Post rejected
+		formPost := url.Values{}
+		formPost.Set("grant_type", "client_credentials")
+		formPost.Set("scope", "read")
+		formPost.Set("client_id", "basic-c")
+		formPost.Set("client_secret", "basic-s")
+		status2, _ := tokenCall(t, "", "", formPost)
+		if status2 != http.StatusUnauthorized {
+			t.Fatalf("post auth on basic client should fail, got %d", status2)
+		}
+	})
+
+	t.Run("client_secret_post: post works, basic rejected", func(t *testing.T) {
+		registerClient(t, "post-c", "post-s", "client_secret_post")
+		// Post OK
+		form := url.Values{}
+		form.Set("grant_type", "client_credentials")
+		form.Set("scope", "read")
+		form.Set("client_id", "post-c")
+		form.Set("client_secret", "post-s")
+		status, body := tokenCall(t, "", "", form)
+		if status != http.StatusOK {
+			t.Fatalf("post auth on post client expected 200, got %d body=%s", status, body)
+		}
+		// Basic rejected
+		form2 := url.Values{}
+		form2.Set("grant_type", "client_credentials")
+		form2.Set("scope", "read")
+		status2, _ := tokenCall(t, "post-c", "post-s", form2)
+		if status2 != http.StatusUnauthorized {
+			t.Fatalf("basic auth on post client should fail, got %d", status2)
+		}
+	})
+
+	t.Run("none: public client + PKCE auth-code works without secret", func(t *testing.T) {
+		registerClient(t, "pub-c", "", "none")
+		mustPostJSON(t, srv.URL+"/test/users", map[string]string{
+			"username": "pub@example.com",
+			"password": "hunter22",
+		})
+		// Authorize with code_challenge.
+		const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+		const challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+		body := mustPostJSON(t, srv.URL+"/test/authorize", map[string]any{
+			"client_id":             "pub-c",
+			"username":              "pub@example.com",
+			"redirect_uri":          "https://app.example.com/cb",
+			"scope":                 "read",
+			"decision":              "approve",
+			"code_challenge":        challenge,
+			"code_challenge_method": "S256",
+		})
+		var ar struct{ RedirectURL string `json:"redirect_url"` }
+		json.Unmarshal(body, &ar)
+		u, _ := url.Parse(ar.RedirectURL)
+		code := u.Query().Get("code")
+
+		// Token exchange: form client_id, no secret, with verifier.
+		form := url.Values{}
+		form.Set("grant_type", "authorization_code")
+		form.Set("code", code)
+		form.Set("redirect_uri", "https://app.example.com/cb")
+		form.Set("client_id", "pub-c")
+		form.Set("code_verifier", verifier)
+		status, respBody := tokenCall(t, "", "", form)
+		if status != http.StatusOK {
+			t.Fatalf("none-client auth-code+PKCE expected 200, got %d body=%s", status, respBody)
+		}
+	})
+
+	t.Run("none: auth-code without PKCE rejected at /test/authorize", func(t *testing.T) {
+		// pub-c already registered above.
+		buf, _ := json.Marshal(map[string]any{
+			"client_id":    "pub-c",
+			"username":     "pub@example.com",
+			"redirect_uri": "https://app.example.com/cb",
+			"scope":        "read",
+			"decision":     "approve",
+			// no code_challenge
+		})
+		resp, _ := http.Post(srv.URL+"/test/authorize", "application/json", bytes.NewReader(buf))
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			t.Fatalf("none-client auth-code without PKCE should fail, got 200 body=%s", body)
+		}
+	})
+
+	t.Run("none: rejects basic auth at token endpoint", func(t *testing.T) {
+		// pub-c is registered as none.
+		form := url.Values{}
+		form.Set("grant_type", "client_credentials")
+		form.Set("scope", "read")
+		status, _ := tokenCall(t, "pub-c", "anything", form)
+		if status != http.StatusUnauthorized {
+			t.Fatalf("none client with basic auth should fail, got %d", status)
+		}
+	})
+
+	t.Run("none: rejects form client_secret", func(t *testing.T) {
+		form := url.Values{}
+		form.Set("grant_type", "client_credentials")
+		form.Set("scope", "read")
+		form.Set("client_id", "pub-c")
+		form.Set("client_secret", "anything")
+		status, _ := tokenCall(t, "", "", form)
+		if status != http.StatusUnauthorized {
+			t.Fatalf("none client with client_secret in form should fail, got %d", status)
+		}
+	})
+
+	t.Run("default (empty) method behaves like client_secret_basic", func(t *testing.T) {
+		// Existing tests already cover this implicitly, but be explicit.
+		mustPostJSON(t, srv.URL+"/test/clients", map[string]string{
+			"key":          "default-c",
+			"secret":       "default-s",
+			"redirect_uri": "https://app.example.com/cb",
+		})
+		form := url.Values{}
+		form.Set("grant_type", "client_credentials")
+		form.Set("scope", "read")
+		status, _ := tokenCall(t, "default-c", "default-s", form)
+		if status != http.StatusOK {
+			t.Fatalf("default client expected 200 with basic auth, got %d", status)
+		}
+	})
+
+	t.Run("revoke and introspect honor the configured method", func(t *testing.T) {
+		// post-c is registered above.
+		// Get a token via post auth.
+		form := url.Values{}
+		form.Set("grant_type", "client_credentials")
+		form.Set("scope", "read")
+		form.Set("client_id", "post-c")
+		form.Set("client_secret", "post-s")
+		_, body := tokenCall(t, "", "", form)
+		var tok struct{ AccessToken string `json:"access_token"` }
+		json.Unmarshal(body, &tok)
+		if tok.AccessToken == "" {
+			t.Fatalf("expected access_token, got %s", body)
+		}
+
+		// Revoke via post auth: OK
+		rForm := url.Values{}
+		rForm.Set("token", tok.AccessToken)
+		rForm.Set("client_id", "post-c")
+		rForm.Set("client_secret", "post-s")
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/revoke", strings.NewReader(rForm.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		resp, _ := http.DefaultClient.Do(req)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("post-auth revoke expected 200, got %d", resp.StatusCode)
+		}
+
+		// Revoke via basic auth on the post-only client: 401
+		req2, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/revoke", strings.NewReader("token=x"))
+		req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req2.SetBasicAuth("post-c", "post-s")
+		resp2, _ := http.DefaultClient.Do(req2)
+		resp2.Body.Close()
+		if resp2.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("basic auth on post-only client at /revoke should be 401, got %d", resp2.StatusCode)
+		}
+	})
+
+	t.Run("unknown auth method at registration returns 400", func(t *testing.T) {
+		buf, _ := json.Marshal(map[string]string{
+			"key":                        "bad-method",
+			"secret":                     "x",
+			"redirect_uri":               "https://x/cb",
+			"token_endpoint_auth_method": "private_key_jwt",
+		})
+		resp, _ := http.Post(srv.URL+"/test/clients", "application/json", bytes.NewReader(buf))
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected 400 on unknown auth method, got %d", resp.StatusCode)
+		}
+	})
+}
+
 func mustGet(t *testing.T, u string) *http.Response {
 	t.Helper()
 	resp, err := http.Get(u)


### PR DESCRIPTION
Closes #10. Tracking: #2.

## Summary

Per-client `token_endpoint_auth_method` per RFC 7591 §2. Clients can now register with one of three methods, and the token / introspect / revoke endpoints enforce the configured method strictly.

| method | request shape |
| --- | --- |
| `client_secret_basic` (default) | HTTP Basic; form `client_id`/`client_secret` rejected |
| `client_secret_post` | form `client_id` + `client_secret`; Basic rejected |
| `none` | form `client_id` only; Basic and form `client_secret` rejected; **PKCE required on `authorization_code`** |

Mismatches return `401 invalid_client`.

## Schema

`migrate0005` calls `AutoMigrate(new(OauthClient))` to add `token_endpoint_auth_method varchar(32) default 'client_secret_basic'`. Additive — existing prod rows continue to use Basic.

## Code

- New `oauth/auth_methods.go` holds the constants, `ValidAuthMethod`, and `authenticateClient` (the single helper called by `tokensHandler`, `introspectHandler`, and `revokeHandler`).
- `CreateClient` signature: `(clientID, secret, redirectURI, tokenEndpointAuthMethod string)`. Empty method → default. Unknown → `ErrInvalidAuthMethod` (400).
- For `none` clients the secret is not hashed/stored.
- `GrantAuthorizationCode` rejects `none` clients without a `code_challenge` via `ErrPublicClientRequiresPKCE`. So both `/web/authorize` and `/test/authorize` get the check for free.
- `/test/clients` now passes `token_endpoint_auth_method` through (previously logged and ignored) and surfaces it in the response.
- Removed the dead `basicAuthClient` method now that `authenticateClient` covers all three modes.
- `oauth/client_test.go` updated for the new signature; existing fixture-based suite still uses the default behaviour because rows from fixtures have empty method = treated as `client_secret_basic`.

## Acceptance criteria

- [x] Client registered with `client_secret_post` rejects Basic; `client_secret_basic` rejects Post
- [x] Public (`none`) client completes auth-code+PKCE without a secret
- [x] Public client without PKCE → 400 at authorize
- [x] Public client rejected when Basic auth or `client_secret` form param is present
- [x] Default (empty) method behaves identically to `client_secret_basic` — existing tests/fixtures unaffected
- [x] Method enforcement applies to `/v1/oauth/{tokens,introspect,revoke}`

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./testmode/...` — 9 new subtests for auth-method behaviour, all prior PR subtests still green
- [x] Live: post-only client rejects Basic with 401; same client accepts post-form with 200; unknown method registration returns 400
- [ ] (Reviewer) confirm production runserver path with existing postgres fixtures (default method behaviour preserved)