### PR TITLE
PR-9: Userinfo + identity simulation (G11)

### DIFF
--- a/models/migrations.go
+++ b/models/migrations.go
@@ -29,6 +29,10 @@ var (
 			Name:     "client_auth_method",
 			Function: migrate0005,
 		},
+		{
+			Name:     "user_identity_columns",
+			Function: migrate0006,
+		},
 	}
 )
 
@@ -167,6 +171,16 @@ func migrate0004(db *gorm.DB, name string) error {
 func migrate0005(db *gorm.DB, name string) error {
 	if err := db.AutoMigrate(new(OauthClient)).Error; err != nil {
 		return fmt.Errorf("Error adding token_endpoint_auth_method column: %s", err)
+	}
+	return nil
+}
+
+// migrate0006 adds the identity columns (email, display_name, sub_override)
+// to oauth_users so /v1/oauth/userinfo can return profile/email claims and
+// test-mode can simulate identity changes between authorizations.
+func migrate0006(db *gorm.DB, name string) error {
+	if err := db.AutoMigrate(new(OauthUser)).Error; err != nil {
+		return fmt.Errorf("Error adding user identity columns: %s", err)
 	}
 	return nil
 }

--- a/models/oauth.go
+++ b/models/oauth.go
@@ -60,6 +60,13 @@ type OauthUser struct {
 	Role     *OauthRole
 	Username string         `sql:"type:varchar(254);unique;not null"`
 	Password sql.NullString `sql:"type:varchar(60)"`
+
+	// Identity attributes returned by /v1/oauth/userinfo. All optional;
+	// when SubOverride is null/empty, userinfo falls back to the user's
+	// UUID for `sub`.
+	Email       sql.NullString `sql:"type:varchar(254)"`
+	DisplayName sql.NullString `sql:"type:varchar(254)"`
+	SubOverride sql.NullString `sql:"type:varchar(254)"`
 }
 
 // TableName specifies table name

--- a/oauth/bearer.go
+++ b/oauth/bearer.go
@@ -1,0 +1,86 @@
+package oauth
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/RichardKnop/go-oauth2-server/util/response"
+)
+
+// ExtractBearerToken pulls a token from the Authorization header. Returns
+// the empty string and an error message suitable for an `error_description`
+// when the header is missing or malformed.
+func ExtractBearerToken(r *http.Request) (string, string) {
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		return "", "missing Authorization header"
+	}
+	parts := strings.SplitN(auth, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") || parts[1] == "" {
+		return "", "Authorization header must be 'Bearer <token>'"
+	}
+	return parts[1], ""
+}
+
+// WriteBearerError writes a Bearer-token error response per RFC 6750 §3.
+// realm defaults to "go_oauth2_server" when empty. scope is optional;
+// include it on insufficient_scope responses.
+func WriteBearerError(w http.ResponseWriter, status int, code, description, realm, scope string) {
+	if realm == "" {
+		realm = "go_oauth2_server"
+	}
+	parts := []string{fmt.Sprintf(`realm="%s"`, realm)}
+	if code != "" {
+		parts = append(parts, fmt.Sprintf(`error="%s"`, code))
+	}
+	if description != "" {
+		parts = append(parts, fmt.Sprintf(`error_description="%s"`, sanitizeBearerHeader(description)))
+	}
+	if scope != "" {
+		parts = append(parts, fmt.Sprintf(`scope="%s"`, scope))
+	}
+	w.Header().Set("WWW-Authenticate", "Bearer "+strings.Join(parts, ", "))
+	response.Error(w, code, status)
+}
+
+func sanitizeBearerHeader(s string) string {
+	r := strings.NewReplacer(`"`, `'`, "\r", " ", "\n", " ")
+	return r.Replace(s)
+}
+
+// HasAllScopes reports whether every space-separated scope in `required`
+// is also present in `granted`.
+func HasAllScopes(granted, required string) bool {
+	if required == "" {
+		return true
+	}
+	grantedSet := make(map[string]struct{})
+	for _, s := range strings.Fields(granted) {
+		grantedSet[s] = struct{}{}
+	}
+	for _, want := range strings.Fields(required) {
+		if _, ok := grantedSet[want]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// HasAnyScope reports whether at least one space-separated scope in
+// `oneOf` is present in `granted`.
+func HasAnyScope(granted, oneOf string) bool {
+	if oneOf == "" {
+		return true
+	}
+	grantedSet := make(map[string]struct{})
+	for _, s := range strings.Fields(granted) {
+		grantedSet[s] = struct{}{}
+	}
+	for _, want := range strings.Fields(oneOf) {
+		if _, ok := grantedSet[want]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/oauth/routes.go
+++ b/oauth/routes.go
@@ -12,6 +12,8 @@ const (
 	introspectPath     = "/" + introspectResource
 	revokeResource     = "revoke"
 	revokePath         = "/" + revokeResource
+	userinfoResource   = "userinfo"
+	userinfoPath       = "/" + userinfoResource
 )
 
 // RegisterRoutes registers route handlers for the oauth service
@@ -40,6 +42,18 @@ func (s *Service) GetRoutes() []routes.Route {
 			Method:      "POST",
 			Pattern:     revokePath,
 			HandlerFunc: s.revokeHandler,
+		},
+		{
+			Name:        "oauth_userinfo_get",
+			Method:      "GET",
+			Pattern:     userinfoPath,
+			HandlerFunc: s.userinfoHandler,
+		},
+		{
+			Name:        "oauth_userinfo_post",
+			Method:      "POST",
+			Pattern:     userinfoPath,
+			HandlerFunc: s.userinfoHandler,
 		},
 	}
 }

--- a/oauth/userinfo.go
+++ b/oauth/userinfo.go
@@ -1,0 +1,75 @@
+package oauth
+
+import (
+	"net/http"
+
+	"github.com/RichardKnop/go-oauth2-server/models"
+	"github.com/RichardKnop/go-oauth2-server/util/response"
+)
+
+// userinfoRequiredScopes are the scopes that satisfy /v1/oauth/userinfo.
+// Tokens that do not have at least one of these in their granted scope
+// receive 403 insufficient_scope.
+const userinfoRequiredScopes = "profile email"
+
+// UserinfoResponse is the JSON returned by /v1/oauth/userinfo. Empty
+// fields are omitted so callers can distinguish "not set" from "empty
+// string".
+type UserinfoResponse struct {
+	Sub               string `json:"sub"`
+	Email             string `json:"email,omitempty"`
+	PreferredUsername string `json:"preferred_username,omitempty"`
+	Name              string `json:"name,omitempty"`
+}
+
+// userinfoHandler handles GET (and POST) /v1/oauth/userinfo. Per RFC 7662
+// §2.1 the endpoint is bearer-authenticated; the access token must have
+// at least one of the userinfoRequiredScopes.
+func (s *Service) userinfoHandler(w http.ResponseWriter, r *http.Request) {
+	token, errDesc := ExtractBearerToken(r)
+	if errDesc != "" {
+		WriteBearerError(w, http.StatusUnauthorized, "invalid_token", errDesc, "", "")
+		return
+	}
+
+	accessToken, err := s.Authenticate(token)
+	if err != nil {
+		WriteBearerError(w, http.StatusUnauthorized, "invalid_token", err.Error(), "", "")
+		return
+	}
+
+	if !HasAnyScope(accessToken.Scope, userinfoRequiredScopes) {
+		WriteBearerError(w, http.StatusForbidden, "insufficient_scope",
+			"token does not include profile or email scope", "", userinfoRequiredScopes)
+		return
+	}
+
+	if !accessToken.UserID.Valid {
+		// client_credentials tokens have no associated user — userinfo is
+		// undefined. Return 403 with a hint.
+		WriteBearerError(w, http.StatusForbidden, "insufficient_scope",
+			"token is not associated with a user", "", "")
+		return
+	}
+
+	user := new(models.OauthUser)
+	if s.db.Where("id = ?", accessToken.UserID.String).First(user).RecordNotFound() {
+		WriteBearerError(w, http.StatusUnauthorized, "invalid_token", "user not found", "", "")
+		return
+	}
+
+	resp := UserinfoResponse{
+		Sub:               user.ID,
+		PreferredUsername: user.Username,
+	}
+	if user.SubOverride.Valid && user.SubOverride.String != "" {
+		resp.Sub = user.SubOverride.String
+	}
+	if user.Email.Valid {
+		resp.Email = user.Email.String
+	}
+	if user.DisplayName.Valid {
+		resp.Name = user.DisplayName.String
+	}
+	response.WriteJSON(w, resp, http.StatusOK)
+}

--- a/testmode/handlers.go
+++ b/testmode/handlers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/RichardKnop/go-oauth2-server/log"
 	"github.com/RichardKnop/go-oauth2-server/oauth/roles"
+	"github.com/RichardKnop/go-oauth2-server/util"
 	"github.com/RichardKnop/go-oauth2-server/util/response"
 )
 
@@ -56,15 +57,21 @@ func (s *Service) createClient(w http.ResponseWriter, r *http.Request) {
 }
 
 type createUserRequest struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
-	Role     string `json:"role"`
+	Username    string `json:"username"`
+	Password    string `json:"password"`
+	Role        string `json:"role"`
+	Email       string `json:"email,omitempty"`
+	DisplayName string `json:"display_name,omitempty"`
+	Sub         string `json:"sub,omitempty"`
 }
 
 type userResponse struct {
-	ID       string `json:"id"`
-	Username string `json:"username"`
-	Role     string `json:"role"`
+	ID          string `json:"id"`
+	Username    string `json:"username"`
+	Role        string `json:"role"`
+	Email       string `json:"email,omitempty"`
+	DisplayName string `json:"display_name,omitempty"`
+	Sub         string `json:"sub,omitempty"`
 }
 
 func (s *Service) createUser(w http.ResponseWriter, r *http.Request) {
@@ -88,11 +95,40 @@ func (s *Service) createUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	response.WriteJSON(w, userResponse{
+	// Apply identity attributes if any were supplied at creation time.
+	updates := map[string]interface{}{}
+	if req.Email != "" {
+		updates["email"] = util.StringOrNull(req.Email)
+	}
+	if req.DisplayName != "" {
+		updates["display_name"] = util.StringOrNull(req.DisplayName)
+	}
+	if req.Sub != "" {
+		updates["sub_override"] = util.StringOrNull(req.Sub)
+	}
+	if len(updates) > 0 {
+		if err := s.db.Model(user).Updates(updates).Error; err != nil {
+			response.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		s.db.Where("id = ?", user.ID).First(user)
+	}
+
+	resp := userResponse{
 		ID:       user.ID,
 		Username: user.Username,
 		Role:     user.RoleID.String,
-	}, http.StatusCreated)
+	}
+	if user.Email.Valid {
+		resp.Email = user.Email.String
+	}
+	if user.DisplayName.Valid {
+		resp.DisplayName = user.DisplayName.String
+	}
+	if user.SubOverride.Valid {
+		resp.Sub = user.SubOverride.String
+	}
+	response.WriteJSON(w, resp, http.StatusCreated)
 }
 
 func (s *Service) health(w http.ResponseWriter, r *http.Request) {

--- a/testmode/identity.go
+++ b/testmode/identity.go
@@ -1,0 +1,121 @@
+package testmode
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/RichardKnop/go-oauth2-server/models"
+	"github.com/RichardKnop/go-oauth2-server/util"
+	"github.com/RichardKnop/go-oauth2-server/util/response"
+	"github.com/gorilla/mux"
+)
+
+type identityRequest struct {
+	Sub         *string `json:"sub,omitempty"`
+	Email       *string `json:"email,omitempty"`
+	DisplayName *string `json:"display_name,omitempty"`
+}
+
+type identityResponse struct {
+	ID          string `json:"id"`
+	Username    string `json:"username"`
+	Email       string `json:"email,omitempty"`
+	DisplayName string `json:"display_name,omitempty"`
+	Sub         string `json:"sub,omitempty"`
+}
+
+// updateIdentity implements POST /test/users/{id}/identity. Only fields
+// present in the request body are updated; missing fields are left alone.
+// Pass an explicit empty string to clear a field.
+func (s *Service) updateIdentity(w http.ResponseWriter, r *http.Request) {
+	userID := mux.Vars(r)["id"]
+	if userID == "" {
+		response.Error(w, "user id required", http.StatusBadRequest)
+		return
+	}
+
+	var req identityRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		response.Error(w, "invalid JSON body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	user := new(models.OauthUser)
+	if s.db.Where("id = ?", userID).First(user).RecordNotFound() {
+		response.Error(w, "user not found", http.StatusNotFound)
+		return
+	}
+
+	updates := map[string]interface{}{}
+	if req.Email != nil {
+		updates["email"] = util.StringOrNull(*req.Email)
+	}
+	if req.DisplayName != nil {
+		updates["display_name"] = util.StringOrNull(*req.DisplayName)
+	}
+	if req.Sub != nil {
+		updates["sub_override"] = util.StringOrNull(*req.Sub)
+	}
+	if len(updates) > 0 {
+		if err := s.db.Model(user).Updates(updates).Error; err != nil {
+			response.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	// Re-read so the response reflects what was actually persisted.
+	s.db.Where("id = ?", userID).First(user)
+	response.WriteJSON(w, marshalIdentity(user), http.StatusOK)
+}
+
+type swapSubjectRequest struct {
+	NewSub string `json:"new_sub"`
+}
+
+// swapSubject implements POST /test/users/{id}/swap-subject. Stronger
+// variant of identity update that only touches sub_override. Empty string
+// clears the override (userinfo falls back to the user's UUID).
+func (s *Service) swapSubject(w http.ResponseWriter, r *http.Request) {
+	userID := mux.Vars(r)["id"]
+	if userID == "" {
+		response.Error(w, "user id required", http.StatusBadRequest)
+		return
+	}
+
+	var req swapSubjectRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		response.Error(w, "invalid JSON body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	user := new(models.OauthUser)
+	if s.db.Where("id = ?", userID).First(user).RecordNotFound() {
+		response.Error(w, "user not found", http.StatusNotFound)
+		return
+	}
+
+	if err := s.db.Model(user).Update("sub_override", util.StringOrNull(req.NewSub)).Error; err != nil {
+		response.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	s.db.Where("id = ?", userID).First(user)
+	response.WriteJSON(w, marshalIdentity(user), http.StatusOK)
+}
+
+func marshalIdentity(user *models.OauthUser) identityResponse {
+	resp := identityResponse{
+		ID:       user.ID,
+		Username: user.Username,
+	}
+	if user.Email.Valid {
+		resp.Email = user.Email.String
+	}
+	if user.DisplayName.Valid {
+		resp.DisplayName = user.DisplayName.String
+	}
+	if user.SubOverride.Valid {
+		resp.Sub = user.SubOverride.String
+	}
+	return resp
+}

--- a/testmode/integration_test.go
+++ b/testmode/integration_test.go
@@ -1611,6 +1611,230 @@ func TestAuthMethodCompatibility(t *testing.T) {
 	})
 }
 
+func TestUserinfoAndIdentity(t *testing.T) {
+	app := newTestApp(t, true)
+	srv := app.server
+
+	mustPostJSON(t, srv.URL+"/test/clients", map[string]string{
+		"key":          "ui-client",
+		"secret":       "ui-secret",
+		"redirect_uri": "https://app.example.com/cb",
+	})
+
+	// Create user with email and display name set up front.
+	userBody := mustPostJSON(t, srv.URL+"/test/users", map[string]string{
+		"username":     "henry@example.com",
+		"password":     "hunter22",
+		"email":        "henry@example.com",
+		"display_name": "Henry",
+	})
+	var user struct{ ID string `json:"id"` }
+	json.Unmarshal(userBody, &user)
+	if user.ID == "" {
+		t.Fatalf("expected user id in response: %s", userBody)
+	}
+
+	getToken := func(t *testing.T, scope string) string {
+		t.Helper()
+		form := url.Values{}
+		form.Set("grant_type", "password")
+		form.Set("username", "henry@example.com")
+		form.Set("password", "hunter22")
+		form.Set("scope", scope)
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth("ui-client", "ui-secret")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("token: %v", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		var tok struct{ AccessToken string `json:"access_token"` }
+		json.Unmarshal(body, &tok)
+		if tok.AccessToken == "" {
+			t.Fatalf("no access token: %s", body)
+		}
+		return tok.AccessToken
+	}
+
+	getUserinfo := func(t *testing.T, token string) (int, http.Header, []byte) {
+		t.Helper()
+		req, _ := http.NewRequest("GET", srv.URL+"/v1/oauth/userinfo", nil)
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("userinfo: %v", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return resp.StatusCode, resp.Header, body
+	}
+
+	t.Run("token with profile scope returns sub/email/name", func(t *testing.T) {
+		at := getToken(t, "profile email")
+		status, _, body := getUserinfo(t, at)
+		if status != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", status, body)
+		}
+		var ui struct {
+			Sub               string `json:"sub"`
+			Email             string `json:"email"`
+			PreferredUsername string `json:"preferred_username"`
+			Name              string `json:"name"`
+		}
+		json.Unmarshal(body, &ui)
+		if ui.Sub != user.ID {
+			t.Fatalf("expected sub=%s, got %q", user.ID, ui.Sub)
+		}
+		if ui.Email != "henry@example.com" {
+			t.Fatalf("expected email henry@example.com, got %q", ui.Email)
+		}
+		if ui.Name != "Henry" {
+			t.Fatalf("expected name Henry, got %q", ui.Name)
+		}
+		if ui.PreferredUsername != "henry@example.com" {
+			t.Fatalf("expected preferred_username henry@example.com, got %q", ui.PreferredUsername)
+		}
+	})
+
+	t.Run("missing bearer returns 401 with WWW-Authenticate", func(t *testing.T) {
+		status, hdr, _ := getUserinfo(t, "")
+		if status != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", status)
+		}
+		if !strings.Contains(hdr.Get("WWW-Authenticate"), `error="invalid_token"`) {
+			t.Fatalf("expected invalid_token WWW-Authenticate, got %q", hdr.Get("WWW-Authenticate"))
+		}
+	})
+
+	t.Run("token without profile/email scope returns 403", func(t *testing.T) {
+		at := getToken(t, "read")
+		status, hdr, body := getUserinfo(t, at)
+		if status != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d body=%s", status, body)
+		}
+		if !strings.Contains(hdr.Get("WWW-Authenticate"), `error="insufficient_scope"`) {
+			t.Fatalf("expected insufficient_scope, got %q", hdr.Get("WWW-Authenticate"))
+		}
+	})
+
+	t.Run("client_credentials token has no user, returns 403", func(t *testing.T) {
+		form := url.Values{}
+		form.Set("grant_type", "client_credentials")
+		form.Set("scope", "profile")
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth("ui-client", "ui-secret")
+		resp, _ := http.DefaultClient.Do(req)
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		var tok struct{ AccessToken string `json:"access_token"` }
+		json.Unmarshal(body, &tok)
+		if tok.AccessToken == "" {
+			t.Fatalf("expected access_token: %s", body)
+		}
+		status, _, _ := getUserinfo(t, tok.AccessToken)
+		if status != http.StatusForbidden {
+			t.Fatalf("expected 403 for client-credentials token, got %d", status)
+		}
+	})
+
+	t.Run("identity update mutates email visible in next userinfo call", func(t *testing.T) {
+		// Existing token before mutation.
+		at := getToken(t, "profile email")
+
+		buf, _ := json.Marshal(map[string]string{"email": "henry+new@example.com"})
+		resp, _ := http.Post(srv.URL+"/test/users/"+user.ID+"/identity", "application/json", bytes.NewReader(buf))
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("identity update expected 200, got %d body=%s", resp.StatusCode, body)
+		}
+
+		// Same token, new userinfo response.
+		_, _, ui := getUserinfo(t, at)
+		var resp2 struct{ Email string }
+		json.Unmarshal(ui, &resp2)
+		if resp2.Email != "henry+new@example.com" {
+			t.Fatalf("expected new email visible to existing token, got %q (body=%s)", resp2.Email, ui)
+		}
+	})
+
+	t.Run("swap-subject changes sub returned by userinfo", func(t *testing.T) {
+		at := getToken(t, "profile")
+		buf, _ := json.Marshal(map[string]string{"new_sub": "iss://example/users/42"})
+		resp, _ := http.Post(srv.URL+"/test/users/"+user.ID+"/swap-subject", "application/json", bytes.NewReader(buf))
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("swap-subject expected 200, got %d", resp.StatusCode)
+		}
+
+		_, _, body := getUserinfo(t, at)
+		var ui struct{ Sub string }
+		json.Unmarshal(body, &ui)
+		if ui.Sub != "iss://example/users/42" {
+			t.Fatalf("expected sub override, got %q (body=%s)", ui.Sub, body)
+		}
+
+		// Clear the override and confirm sub falls back to UUID.
+		buf2, _ := json.Marshal(map[string]string{"new_sub": ""})
+		resp2, _ := http.Post(srv.URL+"/test/users/"+user.ID+"/swap-subject", "application/json", bytes.NewReader(buf2))
+		resp2.Body.Close()
+		_, _, body2 := getUserinfo(t, at)
+		var ui2 struct{ Sub string }
+		json.Unmarshal(body2, &ui2)
+		if ui2.Sub != user.ID {
+			t.Fatalf("expected sub to fall back to UUID, got %q", ui2.Sub)
+		}
+	})
+
+	t.Run("identity update on unknown user returns 404", func(t *testing.T) {
+		buf, _ := json.Marshal(map[string]string{"email": "x"})
+		resp, _ := http.Post(srv.URL+"/test/users/00000000-0000-0000-0000-000000000000/identity", "application/json", bytes.NewReader(buf))
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("revoked access token at userinfo returns 401", func(t *testing.T) {
+		at := getToken(t, "profile")
+		// Revoke via test-mode admin endpoint.
+		buf, _ := json.Marshal(map[string]string{"token": at})
+		resp, _ := http.Post(srv.URL+"/test/revoke", "application/json", bytes.NewReader(buf))
+		resp.Body.Close()
+		status, _, _ := getUserinfo(t, at)
+		if status != http.StatusUnauthorized {
+			t.Fatalf("expected 401 for revoked token at userinfo, got %d", status)
+		}
+	})
+
+	t.Run("userinfo is recordable and scriptable", func(t *testing.T) {
+		app.recorder.Reset()
+		// Script a 503 on userinfo.
+		buf, _ := json.Marshal(map[string]any{
+			"endpoint": "userinfo",
+			"actions":  []map[string]any{{"body_template": "temporarily_unavailable_503"}},
+		})
+		http.Post(srv.URL+"/test/scripts", "application/json", bytes.NewReader(buf))
+
+		at := getToken(t, "profile")
+		status, _, _ := getUserinfo(t, at)
+		if status != http.StatusServiceUnavailable {
+			t.Fatalf("expected scripted 503, got %d", status)
+		}
+		// Real call after queue empties is recorded.
+		getUserinfo(t, at)
+		entries := app.recorder.Snapshot(testmode.SnapshotFilter{Endpoint: "userinfo"})
+		if len(entries) == 0 {
+			t.Fatalf("expected recorded userinfo request")
+		}
+	})
+}
+
 func mustGet(t *testing.T, u string) *http.Response {
 	t.Helper()
 	resp, err := http.Get(u)

--- a/testmode/recorder.go
+++ b/testmode/recorder.go
@@ -105,6 +105,8 @@ func classifyEndpoint(path string, form url.Values) string {
 		return "introspect"
 	case path == "/v1/oauth/revoke":
 		return "revoke"
+	case path == "/v1/oauth/userinfo":
+		return "userinfo"
 	case path == "/test/resource" || strings.HasPrefix(path, "/test/resource/"):
 		return "resource"
 	default:

--- a/testmode/routes.go
+++ b/testmode/routes.go
@@ -84,5 +84,17 @@ func (s *Service) GetRoutes() []routes.Route {
 			Pattern:     "/resource-policy",
 			HandlerFunc: s.resourcePolicyHandler,
 		},
+		{
+			Name:        "test_user_identity",
+			Method:      "POST",
+			Pattern:     "/users/{id}/identity",
+			HandlerFunc: s.updateIdentity,
+		},
+		{
+			Name:        "test_user_swap_subject",
+			Method:      "POST",
+			Pattern:     "/users/{id}/swap-subject",
+			HandlerFunc: s.swapSubject,
+		},
 	}
 }

--- a/testmode/scripts_handlers.go
+++ b/testmode/scripts_handlers.go
@@ -19,6 +19,7 @@ var validScriptEndpoints = map[string]struct{}{
 	"revoke":     {},
 	"resource":   {},
 	"introspect": {},
+	"userinfo":   {},
 }
 
 // enqueueScript implements POST /test/scripts.

--- a/testmode/seed.go
+++ b/testmode/seed.go
@@ -27,6 +27,8 @@ func Seed(db *gorm.DB) error {
 	defaultScopes := []models.OauthScope{
 		{MyGormModel: models.MyGormModel{ID: "1", CreatedAt: now}, Scope: "read", IsDefault: true},
 		{MyGormModel: models.MyGormModel{ID: "2", CreatedAt: now}, Scope: "read_write", IsDefault: false},
+		{MyGormModel: models.MyGormModel{ID: "3", CreatedAt: now}, Scope: "profile", IsDefault: false},
+		{MyGormModel: models.MyGormModel{ID: "4", CreatedAt: now}, Scope: "email", IsDefault: false},
 	}
 	for i := range defaultScopes {
 		sc := defaultScopes[i]


### PR DESCRIPTION
Closes #11. Tracking: #2.

This is the final PR in the gap-closure sequence. After it merges, every checkbox on the meta tracking issue (#2) is green.

## Summary

- **`GET /v1/oauth/userinfo`** (and `POST` per RFC 7662): bearer-authenticated; returns `{sub, email, preferred_username, name}`. Token must include `profile` or `email`; `client_credentials` tokens return 403.
- **Identity simulation in test mode**: `/test/users/{id}/identity` partial-updates email/display_name/sub; `/test/users/{id}/swap-subject` set/clears `sub_override` alone. Existing access tokens see the new identity on subsequent userinfo calls — exactly the AuthProxy "user identity changed at the IdP" scenario.

## Schema

`migrate0006` adds three nullable columns to `oauth_users`: `email`, `display_name`, `sub_override`. Additive via `AutoMigrate`.

## Code

- New `oauth/userinfo.go` with the handler.
- New `oauth/bearer.go` consolidates RFC 6750 helpers — `ExtractBearerToken`, `WriteBearerError`, `HasAllScopes`, `HasAnyScope` — so any future bearer endpoint shares the implementation. (testmode/resource.go could be migrated onto these in a later cleanup.)
- `/test/users` now accepts `email`, `display_name`, `sub` on creation and surfaces them in the response.
- `profile` and `email` added to the test-mode seed scope rows so clients can request them; production fixtures unchanged (existing servers can add them via `loaddata` if they want userinfo).
- `userinfo` added to `classifyEndpoint` and `validScriptEndpoints`, so request recording (PR-2) and script queue (PR-3) just work.

## Acceptance criteria

- [x] Authorize → token (with `profile` scope) → `GET /v1/oauth/userinfo` returns expected `sub`/`email`
- [x] `POST /test/users/{id}/identity` with a new email → next userinfo shows new email **on the same access token** (verified live)
- [x] Token without `profile`/`email` scope → 403 with `WWW-Authenticate: Bearer error=\"insufficient_scope\"`
- [x] Without `--test-mode`, `/test/users/{id}/identity` and `/test/users/{id}/swap-subject` are 404; `/v1/oauth/userinfo` still works
- [x] Revoked access token → 401 from userinfo
- [x] `client_credentials` token → 403 (no user)

## Notes

- The userinfo endpoint is wired in production routes too, not just `--test-mode`. Existing prod deployments will get it from the next deploy + migration. They'll need to add the `profile` and `email` scope rows themselves (e.g. via `loaddata` against an updated fixtures file) if they want clients to be able to request them.
- I deliberately didn't migrate `testmode/resource.go` onto the new `oauth.WriteBearerError` helper in this PR — that's a small followup cleanup.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./testmode/...` — 9 new subtests + every prior PR's subtests still green
- [x] Live: created user with email + display name → userinfo round-trip → `/test/users/{id}/identity` mutates email → same token sees new email → swap-subject changes `sub` → clearing the override falls back to the UUID
- [ ] (Reviewer) confirm production runserver path + the existing postgres-bound oauth/web suites still work