### PR TITLE
Strict-PKCE per-client toggle (require_pkce)

### DIFF
--- a/models/migrations.go
+++ b/models/migrations.go
@@ -33,6 +33,10 @@ var (
 			Name:     "user_identity_columns",
 			Function: migrate0006,
 		},
+		{
+			Name:     "client_require_pkce",
+			Function: migrate0007,
+		},
 	}
 )
 
@@ -181,6 +185,16 @@ func migrate0005(db *gorm.DB, name string) error {
 func migrate0006(db *gorm.DB, name string) error {
 	if err := db.AutoMigrate(new(OauthUser)).Error; err != nil {
 		return fmt.Errorf("Error adding user identity columns: %s", err)
+	}
+	return nil
+}
+
+// migrate0007 adds require_pkce to oauth_clients so confidential clients
+// can opt into the strict PKCE regime. Default false; existing rows are
+// unaffected.
+func migrate0007(db *gorm.DB, name string) error {
+	if err := db.AutoMigrate(new(OauthClient)).Error; err != nil {
+		return fmt.Errorf("Error adding require_pkce column: %s", err)
 	}
 	return nil
 }

--- a/models/oauth.go
+++ b/models/oauth.go
@@ -21,6 +21,15 @@ type OauthClient struct {
 	// Empty string is treated as the default for backwards compatibility
 	// with rows created before this column existed.
 	TokenEndpointAuthMethod string `sql:"type:varchar(32);default:'client_secret_basic'"`
+
+	// RequirePKCE turns on strict PKCE for this client:
+	//   - GrantAuthorizationCode rejects requests without a code_challenge
+	//   - the token endpoint rejects spurious verifiers (verifier sent
+	//     when the auth code has no stored challenge), instead of the
+	//     RFC §4.5 lax behavior.
+	// `none` (public) clients have this set to true automatically at
+	// creation time.
+	RequirePKCE bool `sql:"default:false"`
 }
 
 // TableName specifies table name

--- a/oauth/auth_methods.go
+++ b/oauth/auth_methods.go
@@ -26,9 +26,10 @@ func ValidAuthMethod(m string) bool {
 	return false
 }
 
-// ErrPublicClientRequiresPKCE is returned when GrantAuthorizationCode is
-// called for a `none` client without a code_challenge.
-var ErrPublicClientRequiresPKCE = errors.New("public clients (token_endpoint_auth_method=none) must use PKCE")
+// ErrClientRequiresPKCE is returned when GrantAuthorizationCode is called
+// for a client that requires PKCE (either token_endpoint_auth_method=none
+// or require_pkce=true) but the request omits code_challenge.
+var ErrClientRequiresPKCE = errors.New("client requires PKCE: code_challenge is mandatory")
 
 // authenticateClient resolves and authenticates the client for token,
 // introspect, and revoke endpoints, applying the per-client

--- a/oauth/authorization_code.go
+++ b/oauth/authorization_code.go
@@ -19,12 +19,12 @@ var (
 // and codeChallengeMethod implement RFC 7636 PKCE; both empty means the
 // request did not opt into PKCE.
 //
-// Public clients (token_endpoint_auth_method=none) MUST use PKCE — the
-// code_challenge is required and the call fails with
-// ErrPublicClientRequiresPKCE if absent.
+// Clients with RequirePKCE=true (which `none` clients always are) MUST
+// supply a code_challenge — the call fails with ErrClientRequiresPKCE
+// if absent.
 func (s *Service) GrantAuthorizationCode(client *models.OauthClient, user *models.OauthUser, expiresIn int, redirectURI, scope, codeChallenge, codeChallengeMethod string) (*models.OauthAuthorizationCode, error) {
-	if client.TokenEndpointAuthMethod == AuthMethodNone && codeChallenge == "" {
-		return nil, ErrPublicClientRequiresPKCE
+	if client.RequirePKCE && codeChallenge == "" {
+		return nil, ErrClientRequiresPKCE
 	}
 
 	resolvedMethod, err := validateChallengeAtAuthorize(codeChallenge, codeChallengeMethod)

--- a/oauth/client.go
+++ b/oauth/client.go
@@ -48,13 +48,17 @@ func (s *Service) FindClientByClientID(clientID string) (*models.OauthClient, er
 // CreateClient saves a new client to database. tokenEndpointAuthMethod
 // must be one of "client_secret_basic" (default), "client_secret_post",
 // "none", or empty (treated as the default).
-func (s *Service) CreateClient(clientID, secret, redirectURI, tokenEndpointAuthMethod string) (*models.OauthClient, error) {
-	return s.createClientCommon(s.db, clientID, secret, redirectURI, tokenEndpointAuthMethod)
+//
+// requirePKCE forces strict PKCE for the client (mandatory code_challenge
+// at authorize time, no spurious verifier accepted at the token endpoint).
+// `none` clients always get strict PKCE regardless of this argument.
+func (s *Service) CreateClient(clientID, secret, redirectURI, tokenEndpointAuthMethod string, requirePKCE bool) (*models.OauthClient, error) {
+	return s.createClientCommon(s.db, clientID, secret, redirectURI, tokenEndpointAuthMethod, requirePKCE)
 }
 
 // CreateClientTx saves a new client to database using injected db object.
-func (s *Service) CreateClientTx(tx *gorm.DB, clientID, secret, redirectURI, tokenEndpointAuthMethod string) (*models.OauthClient, error) {
-	return s.createClientCommon(tx, clientID, secret, redirectURI, tokenEndpointAuthMethod)
+func (s *Service) CreateClientTx(tx *gorm.DB, clientID, secret, redirectURI, tokenEndpointAuthMethod string, requirePKCE bool) (*models.OauthClient, error) {
+	return s.createClientCommon(tx, clientID, secret, redirectURI, tokenEndpointAuthMethod, requirePKCE)
 }
 
 // AuthClient authenticates client
@@ -73,7 +77,7 @@ func (s *Service) AuthClient(clientID, secret string) (*models.OauthClient, erro
 	return client, nil
 }
 
-func (s *Service) createClientCommon(db *gorm.DB, clientID, secret, redirectURI, tokenEndpointAuthMethod string) (*models.OauthClient, error) {
+func (s *Service) createClientCommon(db *gorm.DB, clientID, secret, redirectURI, tokenEndpointAuthMethod string, requirePKCE bool) (*models.OauthClient, error) {
 	// Check client ID
 	if s.ClientExists(clientID) {
 		return nil, ErrClientIDTaken
@@ -98,6 +102,11 @@ func (s *Service) createClientCommon(db *gorm.DB, clientID, secret, redirectURI,
 		}
 	}
 
+	// Public clients always require PKCE.
+	if method == AuthMethodNone {
+		requirePKCE = true
+	}
+
 	client := &models.OauthClient{
 		MyGormModel: models.MyGormModel{
 			ID:        uuid.New(),
@@ -107,6 +116,7 @@ func (s *Service) createClientCommon(db *gorm.DB, clientID, secret, redirectURI,
 		Secret:                  string(secretHash),
 		RedirectURI:             util.StringOrNull(redirectURI),
 		TokenEndpointAuthMethod: method,
+		RequirePKCE:             requirePKCE,
 	}
 	if err := db.Create(client).Error; err != nil {
 		return nil, err

--- a/oauth/client_test.go
+++ b/oauth/client_test.go
@@ -47,6 +47,7 @@ func (suite *OauthTestSuite) TestCreateClient() {
 		"test_secret",             // secret
 		"https://www.example.com", // redirect URI
 		"",                        // token_endpoint_auth_method (default)
+		false,                     // require_pkce
 	)
 
 	// Client object should be nil
@@ -63,6 +64,7 @@ func (suite *OauthTestSuite) TestCreateClient() {
 		"test_secret",             // secret
 		"https://www.example.com", // redirect URI
 		"",                        // token_endpoint_auth_method (default)
+		false,                     // require_pkce
 	)
 
 	// Error should be nil

--- a/oauth/errors.go
+++ b/oauth/errors.go
@@ -23,6 +23,8 @@ var (
 		ErrPKCEMethodUnsupported:         http.StatusBadRequest,
 		ErrPKCEVerifierMissing:           http.StatusBadRequest,
 		ErrPKCEVerifierMismatch:          http.StatusBadRequest,
+		ErrPKCEVerifierUnexpected:        http.StatusBadRequest,
+		ErrClientRequiresPKCE:            http.StatusBadRequest,
 		ErrRefreshTokenNotFound:          http.StatusNotFound,
 		ErrTokenMissing:                  http.StatusBadRequest,
 		ErrTokenHintInvalid:              http.StatusBadRequest,

--- a/oauth/grant_type_authorization_code.go
+++ b/oauth/grant_type_authorization_code.go
@@ -27,7 +27,7 @@ func (s *Service) authorizationCodeGrant(r *http.Request, client *models.OauthCl
 	// PKCE verification (RFC 7636). The skip path is reserved for the
 	// test-mode script middleware's skip_pkce_check action.
 	if !skipPKCE(r.Context()) {
-		if err := verifyPKCE(authorizationCode, r.Form.Get("code_verifier")); err != nil {
+		if err := verifyPKCE(authorizationCode, r.Form.Get("code_verifier"), client); err != nil {
 			return nil, err
 		}
 	}

--- a/oauth/pkce.go
+++ b/oauth/pkce.go
@@ -28,6 +28,12 @@ var (
 	// ErrPKCEVerifierMismatch is returned when the supplied code_verifier
 	// fails the challenge check.
 	ErrPKCEVerifierMismatch = errors.New("code_verifier does not match challenge")
+	// ErrPKCEVerifierUnexpected is returned when a strict-PKCE client
+	// (RequirePKCE=true) sends a code_verifier against an authorization
+	// code that has no stored challenge. RFC §4.5 permits ignoring this,
+	// but tests asserting against a misbehaving proxy may want the
+	// failure surfaced — that's what RequirePKCE turns on.
+	ErrPKCEVerifierUnexpected = errors.New("code_verifier sent but no challenge stored")
 )
 
 // pkceSkipKey is the context key used by test-mode scripting to mark a
@@ -70,11 +76,15 @@ func validateChallengeAtAuthorize(challenge, method string) (string, error) {
 // verifyPKCE checks the supplied verifier against the stored challenge.
 // Returns nil if the auth code has no challenge stored (no PKCE was
 // requested) or if the verifier matches.
-func verifyPKCE(code *models.OauthAuthorizationCode, verifier string) error {
+//
+// Strict mode (client.RequirePKCE = true) additionally rejects spurious
+// verifiers — i.e. a verifier sent against a code that has no stored
+// challenge. Lax mode follows RFC §4.5 and ignores them.
+func verifyPKCE(code *models.OauthAuthorizationCode, verifier string, client *models.OauthClient) error {
 	if !code.CodeChallenge.Valid || code.CodeChallenge.String == "" {
-		// No challenge stored — RFC §4.5: spurious verifier is permitted
-		// and ignored. (Strict-rejection mode would belong on a future
-		// per-client setting.)
+		if client != nil && client.RequirePKCE && verifier != "" {
+			return ErrPKCEVerifierUnexpected
+		}
 		return nil
 	}
 	if verifier == "" {

--- a/oauth/pkce_test.go
+++ b/oauth/pkce_test.go
@@ -1,0 +1,96 @@
+package oauth
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/models"
+)
+
+// TestVerifyPKCESpuriousVerifier covers the strict-mode branch in
+// verifyPKCE that can't easily be triggered through the integration
+// suite — by the time we reach the token endpoint with a strict client,
+// the auth code already has a stored challenge (GrantAuthorizationCode
+// rejects strict clients without one). This test simulates the
+// transition case where RequirePKCE is flipped on after a code was
+// issued under lax mode.
+func TestVerifyPKCESpuriousVerifier(t *testing.T) {
+	codeWithoutChallenge := &models.OauthAuthorizationCode{
+		// CodeChallenge intentionally invalid (Valid: false).
+	}
+	codeWithChallenge := &models.OauthAuthorizationCode{
+		CodeChallenge:       sql.NullString{String: "abc", Valid: true},
+		CodeChallengeMethod: sql.NullString{String: PKCEMethodPlain, Valid: true},
+	}
+
+	laxClient := &models.OauthClient{RequirePKCE: false}
+	strictClient := &models.OauthClient{RequirePKCE: true}
+
+	cases := []struct {
+		name    string
+		code    *models.OauthAuthorizationCode
+		client  *models.OauthClient
+		verifier string
+		want    error
+	}{
+		{
+			name:    "lax client, no challenge, no verifier → ok",
+			code:    codeWithoutChallenge,
+			client:  laxClient,
+			verifier: "",
+			want:    nil,
+		},
+		{
+			name:    "lax client, no challenge, spurious verifier → ok (RFC §4.5)",
+			code:    codeWithoutChallenge,
+			client:  laxClient,
+			verifier: "anything",
+			want:    nil,
+		},
+		{
+			name:    "strict client, no challenge, no verifier → ok (transition case)",
+			code:    codeWithoutChallenge,
+			client:  strictClient,
+			verifier: "",
+			want:    nil,
+		},
+		{
+			name:    "strict client, no challenge, spurious verifier → rejected",
+			code:    codeWithoutChallenge,
+			client:  strictClient,
+			verifier: "anything",
+			want:    ErrPKCEVerifierUnexpected,
+		},
+		{
+			name:    "strict client, challenge stored, missing verifier → missing",
+			code:    codeWithChallenge,
+			client:  strictClient,
+			verifier: "",
+			want:    ErrPKCEVerifierMissing,
+		},
+		{
+			name:    "lax client, challenge stored, matching verifier → ok",
+			code:    codeWithChallenge,
+			client:  laxClient,
+			verifier: "abc",
+			want:    nil,
+		},
+		{
+			name:    "nil client behaves as lax (e.g. legacy callsites)",
+			code:    codeWithoutChallenge,
+			client:  nil,
+			verifier: "anything",
+			want:    nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := verifyPKCE(tc.code, tc.verifier, tc.client)
+			if !errors.Is(got, tc.want) {
+				t.Fatalf("verifyPKCE: want %v, got %v", tc.want, got)
+			}
+		})
+	}
+}

--- a/oauth/service_interface.go
+++ b/oauth/service_interface.go
@@ -20,8 +20,8 @@ type ServiceInterface interface {
 	RegisterRoutes(router *mux.Router, prefix string)
 	ClientExists(clientID string) bool
 	FindClientByClientID(clientID string) (*models.OauthClient, error)
-	CreateClient(clientID, secret, redirectURI, tokenEndpointAuthMethod string) (*models.OauthClient, error)
-	CreateClientTx(tx *gorm.DB, clientID, secret, redirectURI, tokenEndpointAuthMethod string) (*models.OauthClient, error)
+	CreateClient(clientID, secret, redirectURI, tokenEndpointAuthMethod string, requirePKCE bool) (*models.OauthClient, error)
+	CreateClientTx(tx *gorm.DB, clientID, secret, redirectURI, tokenEndpointAuthMethod string, requirePKCE bool) (*models.OauthClient, error)
 	AuthClient(clientID, secret string) (*models.OauthClient, error)
 	UserExists(username string) bool
 	FindUserByUsername(username string) (*models.OauthUser, error)

--- a/testmode/authorize.go
+++ b/testmode/authorize.go
@@ -120,7 +120,7 @@ func (s *Service) authorize(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// PKCE input errors are user errors → 400; everything else → 500.
 		switch err {
-		case oauth.ErrPKCEInvalidRequest, oauth.ErrPKCEMethodUnsupported:
+		case oauth.ErrPKCEInvalidRequest, oauth.ErrPKCEMethodUnsupported, oauth.ErrClientRequiresPKCE:
 			response.Error(w, err.Error(), http.StatusBadRequest)
 		default:
 			response.Error(w, "granting authorization code: "+err.Error(), http.StatusInternalServerError)

--- a/testmode/handlers.go
+++ b/testmode/handlers.go
@@ -15,9 +15,11 @@ type createClientRequest struct {
 	Secret      string `json:"secret"`
 	RedirectURI string `json:"redirect_uri"`
 
-	// Accepted but not yet enforced; reserved for PR-3 / PR-8.
-	Scope                   string `json:"scope,omitempty"`
+	// Accepted but not yet enforced; reserved for PR-3.
+	Scope string `json:"scope,omitempty"`
+
 	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`
+	RequirePKCE             bool   `json:"require_pkce,omitempty"`
 }
 
 type clientResponse struct {
@@ -25,6 +27,7 @@ type clientResponse struct {
 	Key                     string `json:"key"`
 	RedirectURI             string `json:"redirect_uri,omitempty"`
 	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`
+	RequirePKCE             bool   `json:"require_pkce,omitempty"`
 }
 
 func (s *Service) createClient(w http.ResponseWriter, r *http.Request) {
@@ -42,7 +45,7 @@ func (s *Service) createClient(w http.ResponseWriter, r *http.Request) {
 			req.Scope)
 	}
 
-	client, err := s.oauthService.CreateClient(req.Key, req.Secret, req.RedirectURI, req.TokenEndpointAuthMethod)
+	client, err := s.oauthService.CreateClient(req.Key, req.Secret, req.RedirectURI, req.TokenEndpointAuthMethod, req.RequirePKCE)
 	if err != nil {
 		response.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -53,6 +56,7 @@ func (s *Service) createClient(w http.ResponseWriter, r *http.Request) {
 		Key:                     client.Key,
 		RedirectURI:             client.RedirectURI.String,
 		TokenEndpointAuthMethod: client.TokenEndpointAuthMethod,
+		RequirePKCE:             client.RequirePKCE,
 	}, http.StatusCreated)
 }
 

--- a/testmode/integration_test.go
+++ b/testmode/integration_test.go
@@ -1835,6 +1835,138 @@ func TestUserinfoAndIdentity(t *testing.T) {
 	})
 }
 
+func TestStrictPKCEPerClient(t *testing.T) {
+	app := newTestApp(t, true)
+	srv := app.server
+
+	const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	const challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+	t.Run("none clients have require_pkce=true reported back", func(t *testing.T) {
+		body := mustPostJSON(t, srv.URL+"/test/clients", map[string]any{
+			"key":                        "auto-strict",
+			"redirect_uri":               "https://app.example.com/cb",
+			"token_endpoint_auth_method": "none",
+		})
+		var resp struct {
+			TokenEndpointAuthMethod string `json:"token_endpoint_auth_method"`
+			RequirePKCE             bool   `json:"require_pkce"`
+		}
+		json.Unmarshal(body, &resp)
+		if resp.TokenEndpointAuthMethod != "none" {
+			t.Fatalf("expected method=none, got %q", resp.TokenEndpointAuthMethod)
+		}
+		if !resp.RequirePKCE {
+			t.Fatalf("none clients should auto-set require_pkce=true, body=%s", body)
+		}
+	})
+
+	t.Run("confidential client with require_pkce: authorize without challenge rejected", func(t *testing.T) {
+		mustPostJSON(t, srv.URL+"/test/clients", map[string]any{
+			"key":          "strict-conf",
+			"secret":       "strict-secret",
+			"redirect_uri": "https://app.example.com/cb",
+			"require_pkce": true,
+		})
+		mustPostJSON(t, srv.URL+"/test/users", map[string]string{
+			"username": "kara@example.com",
+			"password": "hunter22",
+		})
+
+		buf, _ := json.Marshal(map[string]any{
+			"client_id":    "strict-conf",
+			"username":     "kara@example.com",
+			"redirect_uri": "https://app.example.com/cb",
+			"scope":        "read",
+			"decision":     "approve",
+			// no code_challenge
+		})
+		resp, _ := http.Post(srv.URL+"/test/authorize", "application/json", bytes.NewReader(buf))
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("strict confidential client without challenge: expected 400, got %d body=%s", resp.StatusCode, body)
+		}
+		if !strings.Contains(string(body), "PKCE") {
+			t.Fatalf("error should mention PKCE, got %s", body)
+		}
+	})
+
+	t.Run("confidential client with require_pkce: full PKCE flow succeeds", func(t *testing.T) {
+		// strict-conf already registered above.
+		buf, _ := json.Marshal(map[string]any{
+			"client_id":             "strict-conf",
+			"username":              "kara@example.com",
+			"redirect_uri":          "https://app.example.com/cb",
+			"scope":                 "read",
+			"decision":              "approve",
+			"code_challenge":        challenge,
+			"code_challenge_method": "S256",
+		})
+		resp, _ := http.Post(srv.URL+"/test/authorize", "application/json", bytes.NewReader(buf))
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		var ar struct{ RedirectURL string `json:"redirect_url"` }
+		json.Unmarshal(body, &ar)
+		u, _ := url.Parse(ar.RedirectURL)
+		code := u.Query().Get("code")
+
+		form := url.Values{}
+		form.Set("grant_type", "authorization_code")
+		form.Set("code", code)
+		form.Set("redirect_uri", "https://app.example.com/cb")
+		form.Set("code_verifier", verifier)
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth("strict-conf", "strict-secret")
+		tokenResp, _ := http.DefaultClient.Do(req)
+		body2, _ := io.ReadAll(tokenResp.Body)
+		tokenResp.Body.Close()
+		if tokenResp.StatusCode != http.StatusOK {
+			t.Fatalf("strict client + full PKCE expected 200, got %d body=%s", tokenResp.StatusCode, body2)
+		}
+	})
+
+	t.Run("non-strict client still allows spurious verifier (RFC §4.5)", func(t *testing.T) {
+		mustPostJSON(t, srv.URL+"/test/clients", map[string]any{
+			"key":          "lax-conf",
+			"secret":       "lax-secret",
+			"redirect_uri": "https://app.example.com/cb",
+		})
+		buf, _ := json.Marshal(map[string]any{
+			"client_id":    "lax-conf",
+			"username":     "kara@example.com",
+			"redirect_uri": "https://app.example.com/cb",
+			"scope":        "read",
+			"decision":     "approve",
+			// no code_challenge
+		})
+		resp, _ := http.Post(srv.URL+"/test/authorize", "application/json", bytes.NewReader(buf))
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		var ar struct{ RedirectURL string `json:"redirect_url"` }
+		json.Unmarshal(body, &ar)
+		u, _ := url.Parse(ar.RedirectURL)
+		code := u.Query().Get("code")
+
+		// Send a spurious verifier. Lax clients ignore it.
+		form := url.Values{}
+		form.Set("grant_type", "authorization_code")
+		form.Set("code", code)
+		form.Set("redirect_uri", "https://app.example.com/cb")
+		form.Set("code_verifier", "SPURIOUS")
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth("lax-conf", "lax-secret")
+		tokenResp, _ := http.DefaultClient.Do(req)
+		body2, _ := io.ReadAll(tokenResp.Body)
+		tokenResp.Body.Close()
+		if tokenResp.StatusCode != http.StatusOK {
+			t.Fatalf("lax client should accept spurious verifier, got %d body=%s", tokenResp.StatusCode, body2)
+		}
+	})
+}
+
 func mustGet(t *testing.T, u string) *http.Response {
 	t.Helper()
 	resp, err := http.Get(u)


### PR DESCRIPTION
Followup to the gap-closure series (#2). Implements the per-client strict-PKCE toggle flagged as a possible followup in PR-7's body.

## Summary

`OauthClient` gains a `require_pkce` bool column (migrate0007 via `AutoMigrate`, additive default false). When set:

- `GrantAuthorizationCode` rejects requests without `code_challenge` → `ErrClientRequiresPKCE` (400)
- `verifyPKCE` rejects spurious verifiers — i.e. a `code_verifier` sent against a code that has no stored challenge → `ErrPKCEVerifierUnexpected` (400). RFC §4.5 still permits ignoring them in the default lax mode.

`token_endpoint_auth_method=none` clients have `RequirePKCE` auto-set to true at creation. The public-client + PKCE invariant from PR-8 is now expressed via this single flag instead of a method-name check.

## Schema

`migrate0007` adds `require_pkce` via `AutoMigrate`. Default `false` — existing rows keep the lax behavior.

## API

`POST /test/clients` accepts `require_pkce: true|false` and echoes it in the response. Combined with `token_endpoint_auth_method`, tests can register:

| auth method | require_pkce | result |
| --- | --- | --- |
| `client_secret_basic` (or empty) | `false` | lax (existing behavior) |
| `client_secret_basic` | `true` | strict confidential client |
| `none` | (any) | always strict; flag forced true at creation |

## Renames

`ErrPublicClientRequiresPKCE` → `ErrClientRequiresPKCE` with a generalized message. Only internal callers, no external users.

## Tests

- `oauth/pkce_test.go` — 7-case table-driven unit test for `verifyPKCE`. Covers lax/strict × challenge-present/absent × verifier-present/absent, plus a nil-client-as-lax sanity case. Internal package test (`package oauth`) so it can call `verifyPKCE` directly; the postgres-bound suite continues to live in `package oauth_test` and isn't affected.
- `testmode/integration_test.go` — `TestStrictPKCEPerClient` with 4 subtests:
  - `none` clients report `require_pkce: true` in the create response
  - strict confidential client rejects no-challenge authorize → 400
  - strict confidential client + full PKCE flow → 200
  - lax confidential client still accepts spurious verifiers (RFC §4.5)

## Bonus fix found while testing

The existing PR-9 integration assertion for "no challenge stored on a strict client" only checked `!= 200`, which silently masked a 500-vs-400 mapping bug in `testmode/authorize.go` (the new `ErrClientRequiresPKCE` wasn't in the input-error switch). Tightened the assertion to require 400 specifically and added the error to the switch.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./testmode/...` — 4 new subtests + everything from the gap-closure PRs still green
- [x] `go test -run TestVerifyPKCESpuriousVerifier ./oauth/` — 7 unit cases green
- [x] Live: `require_pkce: true` echoes back; `none` client auto-sets it; strict client + no challenge → 400
- [ ] (Reviewer) confirm production runserver path with the postgres-bound suite (existing oauth/web tests)