### PR TITLE
Mount /test/resource on the production server

### DIFF
--- a/cmd/run_server.go
+++ b/cmd/run_server.go
@@ -40,6 +40,12 @@ func RunServer(configBackend string) error {
 	services.OauthService.RegisterRoutes(router, "/v1/oauth")
 	services.WebService.RegisterRoutes(router, "/web")
 
+	// /test/resource/{path} is a sample protected resource intended for
+	// manual OAuth-flow validation against this server: register a client,
+	// get a token, hit it with `Authorization: Bearer <token>`. No script
+	// queue, no recorder, no scope policy — those live in --test-mode.
+	services.OauthService.RegisterSampleResource(router, "/test/resource")
+
 	// Set the router
 	app.UseHandler(router)
 

--- a/oauth/sample_resource.go
+++ b/oauth/sample_resource.go
@@ -1,0 +1,71 @@
+package oauth
+
+import (
+	"net/http"
+
+	"github.com/RichardKnop/go-oauth2-server/models"
+	"github.com/RichardKnop/go-oauth2-server/util/response"
+	"github.com/gorilla/mux"
+)
+
+// ScopePolicyFunc returns the required scope (space-separated) for the
+// given path. ok=false means no policy is registered for the path.
+type ScopePolicyFunc func(path string) (required string, ok bool)
+
+// ServeSampleResource is the shared sample protected-resource handler:
+// bearer auth + optional per-path scope policy + default JSON body.
+//
+// In production it is mounted as a sample target so an operator can
+// validate an OAuth flow end-to-end (register a client, get a token,
+// hit the resource). In test mode it gets a non-nil policy callback so
+// /test/resource-policy registrations are honored.
+//
+// realm appears in WWW-Authenticate; pass "" for the package default.
+func (s *Service) ServeSampleResource(w http.ResponseWriter, r *http.Request, realm string, policy ScopePolicyFunc) {
+	token, errDesc := ExtractBearerToken(r)
+	if errDesc != "" {
+		WriteBearerError(w, http.StatusUnauthorized, "invalid_token", errDesc, realm, "")
+		return
+	}
+	accessToken, err := s.Authenticate(token)
+	if err != nil {
+		WriteBearerError(w, http.StatusUnauthorized, "invalid_token", err.Error(), realm, "")
+		return
+	}
+	if policy != nil {
+		if required, ok := policy(r.URL.Path); ok {
+			if !HasAllScopes(accessToken.Scope, required) {
+				WriteBearerError(w, http.StatusForbidden, "insufficient_scope",
+					"token does not have required scope(s)", realm, required)
+				return
+			}
+		}
+	}
+	response.WriteJSON(w, sampleResourceBody(accessToken, r), http.StatusOK)
+}
+
+// SampleResourceHandler is the no-policy variant suitable for the
+// production server. Mounted by RegisterSampleResource.
+func (s *Service) SampleResourceHandler(w http.ResponseWriter, r *http.Request) {
+	s.ServeSampleResource(w, r, "sample", nil)
+}
+
+// RegisterSampleResource mounts the sample resource as a catch-all under
+// `prefix` so any HTTP method and any sub-path matches. Typical prefix
+// is "/test/resource".
+func (s *Service) RegisterSampleResource(router *mux.Router, prefix string) {
+	router.PathPrefix(prefix + "/").HandlerFunc(s.SampleResourceHandler)
+}
+
+func sampleResourceBody(accessToken *models.OauthAccessToken, r *http.Request) map[string]any {
+	body := map[string]any{
+		"sub":       accessToken.UserID.String,
+		"client_id": accessToken.ClientID.String,
+		"scope":     accessToken.Scope,
+		"path":      r.URL.Path,
+	}
+	if r.Method != http.MethodGet && r.Method != "" {
+		body["method"] = r.Method
+	}
+	return body
+}

--- a/oauth/service_interface.go
+++ b/oauth/service_interface.go
@@ -1,6 +1,8 @@
 package oauth
 
 import (
+	"net/http"
+
 	"github.com/RichardKnop/go-oauth2-server/config"
 	"github.com/RichardKnop/go-oauth2-server/models"
 	"github.com/RichardKnop/go-oauth2-server/session"
@@ -48,5 +50,8 @@ type ServiceInterface interface {
 	AdminRevokeByToken(token string) (bool, error)
 	AdminRevokeByUser(userID string) (int64, int64, error)
 	AdminRevokeByClient(clientID string) (int64, int64, error)
+	ServeSampleResource(w http.ResponseWriter, r *http.Request, realm string, policy ScopePolicyFunc)
+	SampleResourceHandler(w http.ResponseWriter, r *http.Request)
+	RegisterSampleResource(router *mux.Router, prefix string)
 	Close()
 }

--- a/testmode/integration_test.go
+++ b/testmode/integration_test.go
@@ -24,6 +24,7 @@ import (
 type testApp struct {
 	server   *httptest.Server
 	recorder *testmode.Recorder
+	oauth    *oauth.Service
 }
 
 func newTestApp(t *testing.T, withTestMode bool) *testApp {
@@ -58,12 +59,16 @@ func newTestApp(t *testing.T, withTestMode bool) *testApp {
 		app.Use(ts.ScriptMiddleware())
 		ts.RegisterRoutes(router, "/test")
 		rec = ts.Recorder()
+	} else {
+		// Mirror cmd/run_server.go: production also mounts the sample
+		// protected resource so manual OAuth-flow validation works.
+		oauthService.RegisterSampleResource(router, "/test/resource")
 	}
 	app.UseHandler(router)
 
 	srv := httptest.NewServer(app)
 	t.Cleanup(srv.Close)
-	return &testApp{server: srv, recorder: rec}
+	return &testApp{server: srv, recorder: rec, oauth: oauthService}
 }
 
 func TestTestModeBootstrap(t *testing.T) {
@@ -166,6 +171,83 @@ func TestProductionModeOmitsTestRoutes(t *testing.T) {
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected 404 when test-mode is off, got %d", resp.StatusCode)
 	}
+}
+
+// TestProductionSampleResource verifies that /test/resource/{path} is
+// available outside of --test-mode for manual OAuth-flow validation.
+// The control-plane endpoints (/test/clients, /test/resource-policy,
+// /test/scripts, etc.) remain test-mode-only.
+func TestProductionSampleResource(t *testing.T) {
+	app := newTestApp(t, false)
+	srv := app.server
+
+	// No /test/clients in production — register the client directly.
+	if _, err := app.oauth.CreateClient("prod-c", "prod-s", "https://x/cb", "", false); err != nil {
+		t.Fatalf("CreateClient: %v", err)
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("scope", "read")
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth("prod-c", "prod-s")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("token expected 200, got %d body=%s", resp.StatusCode, body)
+	}
+	var tok struct{ AccessToken string `json:"access_token"` }
+	json.Unmarshal(body, &tok)
+	if tok.AccessToken == "" {
+		t.Fatalf("no access token: %s", body)
+	}
+
+	t.Run("valid bearer returns 200 with default body", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", srv.URL+"/test/resource/foo", nil)
+		req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+		r, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		body, _ := io.ReadAll(r.Body)
+		r.Body.Close()
+		if r.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", r.StatusCode, body)
+		}
+		var doc map[string]any
+		json.Unmarshal(body, &doc)
+		if doc["path"] != "/test/resource/foo" || doc["scope"] != "read" {
+			t.Fatalf("unexpected body %s", body)
+		}
+	})
+
+	t.Run("missing bearer returns 401", func(t *testing.T) {
+		r, _ := http.Get(srv.URL + "/test/resource/foo")
+		r.Body.Close()
+		if r.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", r.StatusCode)
+		}
+		if !strings.Contains(r.Header.Get("WWW-Authenticate"), `error="invalid_token"`) {
+			t.Fatalf("expected invalid_token, got %q", r.Header.Get("WWW-Authenticate"))
+		}
+	})
+
+	t.Run("control-plane endpoints stay 404 in production", func(t *testing.T) {
+		// /test/health, /test/clients, /test/scripts, /test/resource-policy
+		// are all testmode-only.
+		for _, path := range []string{"/test/health", "/test/clients", "/test/scripts", "/test/resource-policy"} {
+			r, _ := http.Get(srv.URL + path)
+			r.Body.Close()
+			if r.StatusCode != http.StatusNotFound && r.StatusCode != http.StatusMethodNotAllowed {
+				t.Fatalf("expected 404/405 for %s in production, got %d", path, r.StatusCode)
+			}
+		}
+	})
 }
 
 func TestProgrammaticAuthorize(t *testing.T) {

--- a/testmode/resource.go
+++ b/testmode/resource.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/RichardKnop/go-oauth2-server/oauth"
 	"github.com/RichardKnop/go-oauth2-server/util/response"
 )
 
@@ -41,49 +40,15 @@ func (p *resourcePolicies) clear() {
 	p.rules = make(map[string]string)
 }
 
-// resourceHandler implements ANY /test/resource/{path}. The script
-// middleware runs first, so by the time we get here any queued action has
-// either replaced the response or fallen through.
+// resourceHandler implements ANY /test/resource/{path} in test mode.
+// Delegates to oauth.ServeSampleResource for bearer auth + body, with
+// the per-path scope policy registered via /test/resource-policy.
 //
-// Auth: Bearer token in Authorization header. Token must be a valid
-// (unexpired, unrevoked) access token. Returns 401 invalid_token otherwise.
-//
-// Scope: if a policy is registered for this path, every required scope
-// must be present in the token's scopes. Mismatch returns 403
-// insufficient_scope.
-//
-// Default body: 200 with {sub, client_id, scope, path}. The recorder
-// captures the inbound request automatically.
+// The script middleware runs first, so any queued action has already
+// either replaced the response or fallen through by the time we get
+// here. The recorder captures the inbound request automatically.
 func (s *Service) resourceHandler(w http.ResponseWriter, r *http.Request) {
-	token, errDesc := oauth.ExtractBearerToken(r)
-	if errDesc != "" {
-		oauth.WriteBearerError(w, http.StatusUnauthorized, "invalid_token", errDesc, "test", "")
-		return
-	}
-
-	accessToken, err := s.oauthService.Authenticate(token)
-	if err != nil {
-		oauth.WriteBearerError(w, http.StatusUnauthorized, "invalid_token", err.Error(), "test", "")
-		return
-	}
-
-	if required, ok := s.resourcePolicies.get(r.URL.Path); ok {
-		if !oauth.HasAllScopes(accessToken.Scope, required) {
-			oauth.WriteBearerError(w, http.StatusForbidden, "insufficient_scope", "token does not have required scope(s)", "test", required)
-			return
-		}
-	}
-
-	body := map[string]any{
-		"sub":       accessToken.UserID.String,
-		"client_id": accessToken.ClientID.String,
-		"scope":     accessToken.Scope,
-		"path":      r.URL.Path,
-	}
-	if r.Method != http.MethodGet && r.Method != "" {
-		body["method"] = r.Method
-	}
-	response.WriteJSON(w, body, http.StatusOK)
+	s.oauthService.ServeSampleResource(w, r, "test", s.resourcePolicies.get)
 }
 
 // resourcePolicyRequest is the body of POST /test/resource-policy.


### PR DESCRIPTION
Make `/test/resource/{path}` available outside of `--test-mode` so an operator can validate an OAuth flow end-to-end against a real protected resource (register a client, get a token, hit the resource).

## Changes

- **New `oauth/sample_resource.go`** factors the resource handler into one place:
  - `ServeSampleResource(w, r, realm, ScopePolicyFunc)` — bearer auth + optional per-path scope policy + default JSON body
  - `SampleResourceHandler(w, r)` — no-policy variant for production
  - `RegisterSampleResource(router, prefix)` — catch-all mount, ANY HTTP method
  - `ScopePolicyFunc` is `func(path string) (required string, ok bool)` — same shape `testmode.resourcePolicies.get` already returned
- **`cmd/run_server.go`** mounts the bare handler at `/test/resource`. Production runserver now answers manual OAuth flows.
- **`testmode/resource.go::resourceHandler`** shrinks to a one-liner that delegates to `ServeSampleResource` with the `/test/resource-policy` registry as the policy callback. Behavior unchanged.

## What's still test-mode only

Only the bare resource handler ships in production. These remain `--test-mode` gated:

- Request recorder (`/test/requests`)
- Script queue (`/test/scripts`)
- Per-path scope policies (`/test/resource-policy`)
- `/test/health`, `/test/clients`, `/test/users`, `/test/authorize`, `/test/revoke`, `/test/refresh-tokens/rotate-policy`, `/test/users/{id}/identity`, `/test/users/{id}/swap-subject`

`TestProductionSampleResource` asserts each of `{health, clients, scripts, resource-policy}` returns 404/405 on the production-mode app.

## Path naming

Kept `/test/resource/...` consistent across modes. Happy to rename to `/sample/resource/...` or `/v1/oauth/resource/...` if the `/test/` prefix bothers you in the production routes — let me know.

## Acceptance / test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./testmode/...` — 3 new subtests for the production-side mount, all prior testmode subtests still green (the testmode wrapper preserves identical behavior)
- [x] `go test ./oauth/ -run TestVerifyPKCESpuriousVerifier` — internal unit tests still green
- [ ] (Reviewer) confirm production runserver path works against real postgres + etcd: `runserver` → register client+user via existing fixtures/loaddata → token via `/v1/oauth/tokens` → bearer-hit `/test/resource/foo` → 200 with `{sub, client_id, scope, path}`

## Why this is small

Most of the diff is the test for the production path. The production handler itself is `ServeSampleResource(w, r, "sample", nil)` and the route registration is one line in `cmd/run_server.go`.