### PR TITLE
Seed profile and email scopes in production fixtures

### DIFF
--- a/oauth/fixtures/scopes.yml
+++ b/oauth/fixtures/scopes.yml
@@ -21,3 +21,21 @@
     is_default: false
     created_at: 'ON_INSERT_NOW()'
     updated_at: 'ON_UPDATE_NOW()'
+
+- table: 'oauth_scopes'
+  pk:
+    id: "3"
+  fields:
+    scope: 'profile'
+    is_default: false
+    created_at: 'ON_INSERT_NOW()'
+    updated_at: 'ON_UPDATE_NOW()'
+
+- table: 'oauth_scopes'
+  pk:
+    id: "4"
+  fields:
+    scope: 'email'
+    is_default: false
+    created_at: 'ON_INSERT_NOW()'
+    updated_at: 'ON_UPDATE_NOW()'


### PR DESCRIPTION
Loose end from the gap-closure series. The testmode seed has had `profile` and `email` since PR-9 (#11), but `oauth/fixtures/scopes.yml` only loads `read` and `read_write` — so a fresh prod install can't grant either scope, and `/v1/oauth/userinfo` returns 403 to every token.

## Change

Two new rows in `oauth/fixtures/scopes.yml`, ids 3 and 4 (matching the testmode seed):

```yaml
- table: 'oauth_scopes'
  pk: { id: "3" }
  fields: { scope: 'profile', is_default: false, ... }

- table: 'oauth_scopes'
  pk: { id: "4" }
  fields: { scope: 'email', is_default: false, ... }
```

`is_default` stays false — userinfo is opt-in via explicit `scope=profile` or `scope=email` on the token request.

## Operator note

This only takes effect when `loaddata oauth/fixtures/scopes.yml` is run. Existing prod databases that already have rows 1 and 2 won't be touched by go-fixtures; running loaddata again is the upgrade path.

## Test plan

- YAML-only change. `go build ./... && go vet ./...` still pass.