### PR TITLE
Phase 1: Integration test scaffolding & shared harness

### DIFF
--- a/cmd/run_test_server.go
+++ b/cmd/run_test_server.go
@@ -12,14 +12,15 @@ import (
 	"github.com/RichardKnop/go-oauth2-server/services"
 	"github.com/RichardKnop/go-oauth2-server/testmode"
 	"github.com/RichardKnop/go-oauth2-server/util/migrations"
-	"github.com/gorilla/mux"
-	"github.com/phyber/negroni-gzip/gzip"
-	"github.com/urfave/negroni"
 	"gopkg.in/tylerb/graceful.v1"
 )
 
 // RunTestServer boots the server in headless test-provider mode: no remote
 // config, embedded SQLite, control-plane routes mounted under /test.
+//
+// The handler assembly itself lives in testmode.BuildTestApp so the same
+// middleware chain is used by integration tests, ensuring the binary and
+// the test harness can't drift.
 func RunTestServer(dbPath string, port int) error {
 	cnf := testmode.NewConfig(dbPath)
 
@@ -45,31 +46,17 @@ func RunTestServer(dbPath string, port int) error {
 	defer services.Close()
 
 	testService := testmode.NewService(cnf, db, services.OauthService)
-
-	app := negroni.New()
-	app.Use(negroni.NewRecovery())
-	app.Use(negroni.NewLogger())
-	// Recorder + script middleware run BEFORE gzip so script-injected
-	// responses (and hijacked connections for drop_connection) bypass the
-	// gzip writer wrap.
-	app.Use(testService.Middleware())
-	app.Use(testService.ScriptMiddleware())
-	app.Use(gzip.Gzip(gzip.DefaultCompression))
-	app.Use(negroni.NewStatic(http.Dir("public")))
-
-	router := mux.NewRouter()
-	services.HealthService.RegisterRoutes(router, "/v1")
-	services.OauthService.RegisterRoutes(router, "/v1/oauth")
-	services.WebService.RegisterRoutes(router, "/web")
-	testService.RegisterRoutes(router, "/test")
-
-	app.UseHandler(router)
+	handler := testmode.BuildTestApp(
+		services.HealthService,
+		services.OauthService,
+		services.WebService,
+		testService,
+	)
 
 	addr := fmt.Sprintf(":%d", port)
 
 	// Pre-bind the listener so we can surface a clean error if the port is
-	// in use. graceful.Run otherwise log.Fatals from a goroutine, which is
-	// hard to read.
+	// in use. graceful otherwise log.Fatals from a goroutine.
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return fmt.Errorf("test-mode: cannot bind %s: %w (try --test-port=<n>)", addr, err)
@@ -79,7 +66,7 @@ func RunTestServer(dbPath string, port int) error {
 
 	srv := &graceful.Server{
 		Timeout: 5 * time.Second,
-		Server:  &http.Server{Addr: addr, Handler: app},
+		Server:  &http.Server{Addr: addr, Handler: handler},
 	}
 	if err := srv.Serve(ln); err != nil {
 		return fmt.Errorf("test-mode: server stopped: %w", err)

--- a/integration/binary_smoke_test.go
+++ b/integration/binary_smoke_test.go
@@ -1,0 +1,92 @@
+package integration_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestBinarySmoke proves the runserver --test-mode CLI path works
+// end-to-end: builds the binary, starts it on a free port, polls
+// /test/health until 200, then tears down. The in-process harness used
+// by the rest of this suite goes through testmode.BuildTestApp directly
+// — this test is the only one that exercises cmd.RunTestServer + its
+// graceful.Server wrapper + the actual `runserver --test-mode` CLI
+// argument plumbing.
+//
+// Slow test (~5–15s for the build) so it lives at the package boundary
+// and runs once per `go test ./integration/...` invocation.
+func TestBinarySmoke(t *testing.T) {
+	bin := buildBinary(t)
+	port := freePort(t)
+
+	cmd := exec.Command(bin, "runserver", "--test-mode", "--test-port", strconv.Itoa(port))
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	if !waitForHealth(t, port, 20*time.Second) {
+		t.Fatalf("server didn't become healthy in time. stdout/stderr:\n%s", out.String())
+	}
+}
+
+// buildBinary compiles the project's main package into a temp file and
+// returns the path. Reuses the test's TempDir so cleanup is automatic.
+func buildBinary(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "go-oauth2-server-binary-smoke")
+	cmd := exec.Command("go", "build", "-o", bin, "..")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// freePort asks the OS for a free TCP port, closes the listener, and
+// returns the port number. There is a small race window between close
+// and the binary calling net.Listen, but for a single test in a single
+// process it is reliable.
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("free port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+	return port
+}
+
+// waitForHealth polls GET /test/health until 200 or the deadline.
+func waitForHealth(t *testing.T, port int, timeout time.Duration) bool {
+	t.Helper()
+	url := fmt.Sprintf("http://127.0.0.1:%d/test/health", port)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return true
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return false
+}

--- a/integration/helpers_test.go
+++ b/integration/helpers_test.go
@@ -1,0 +1,364 @@
+package integration_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/oauth"
+	"github.com/RichardKnop/go-oauth2-server/testmode"
+)
+
+// registeredClient captures the bits a scenario test needs to drive an
+// OAuth flow against a particular client (key, secret, redirect URI,
+// auth method).
+type registeredClient struct {
+	ID                      string `json:"id"`
+	Key                     string `json:"key"`
+	Secret                  string `json:"-"` // not serialized; held by the test
+	RedirectURI             string `json:"redirect_uri"`
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method"`
+	RequirePKCE             bool   `json:"require_pkce"`
+}
+
+type registeredUser struct {
+	ID          string `json:"id"`
+	Username    string `json:"username"`
+	Role        string `json:"role"`
+	Email       string `json:"email,omitempty"`
+	DisplayName string `json:"display_name,omitempty"`
+	Sub         string `json:"sub,omitempty"`
+}
+
+// tokenResponse is the typed view of a /v1/oauth/tokens response.
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+	Scope        string `json:"scope"`
+	ExpiresIn    int    `json:"expires_in"`
+	UserID       string `json:"user_id,omitempty"`
+}
+
+// clientOpts are optional knobs for registerClient.
+type clientOpts struct {
+	AuthMethod  string
+	RequirePKCE bool
+}
+
+func registerClient(t *testing.T, ts *testServer, key, secret, redirectURI string, opts ...clientOpts) *registeredClient {
+	t.Helper()
+	body := map[string]any{
+		"key":          key,
+		"redirect_uri": redirectURI,
+	}
+	if secret != "" {
+		body["secret"] = secret
+	}
+	if len(opts) > 0 {
+		o := opts[0]
+		if o.AuthMethod != "" {
+			body["token_endpoint_auth_method"] = o.AuthMethod
+		}
+		if o.RequirePKCE {
+			body["require_pkce"] = true
+		}
+	}
+	respBytes := postJSON(t, ts.URL+"/test/clients", body, http.StatusCreated)
+	var c registeredClient
+	if err := json.Unmarshal(respBytes, &c); err != nil {
+		t.Fatalf("decode client: %v body=%s", err, respBytes)
+	}
+	c.Secret = secret
+	return &c
+}
+
+type userOpts struct {
+	Role        string
+	Email       string
+	DisplayName string
+	Sub         string
+}
+
+func registerUser(t *testing.T, ts *testServer, username, password string, opts ...userOpts) *registeredUser {
+	t.Helper()
+	body := map[string]any{
+		"username": username,
+		"password": password,
+	}
+	if len(opts) > 0 {
+		o := opts[0]
+		if o.Role != "" {
+			body["role"] = o.Role
+		}
+		if o.Email != "" {
+			body["email"] = o.Email
+		}
+		if o.DisplayName != "" {
+			body["display_name"] = o.DisplayName
+		}
+		if o.Sub != "" {
+			body["sub"] = o.Sub
+		}
+	}
+	respBytes := postJSON(t, ts.URL+"/test/users", body, http.StatusCreated)
+	var u registeredUser
+	if err := json.Unmarshal(respBytes, &u); err != nil {
+		t.Fatalf("decode user: %v body=%s", err, respBytes)
+	}
+	return &u
+}
+
+// authorizeParams are the inputs to /test/authorize. Mirrors the request
+// shape of the endpoint.
+type authorizeParams struct {
+	Client              *registeredClient
+	User                *registeredUser // user_id is taken from User.ID; ignored for client_credentials flows
+	Username            string          // alternative to User.ID for ergonomics
+	RedirectURI         string          // defaults to Client.RedirectURI
+	Scope               string
+	State               string
+	GrantedScope        string
+	CodeChallenge       string
+	CodeChallengeMethod string
+}
+
+// authorize calls /test/authorize with the given decision and returns
+// the redirect URL the proxy would have followed.
+func authorize(t *testing.T, ts *testServer, decision string, p authorizeParams) string {
+	t.Helper()
+	body := map[string]any{
+		"client_id": p.Client.Key,
+		"decision":  decision,
+	}
+	redirectURI := p.RedirectURI
+	if redirectURI == "" {
+		redirectURI = p.Client.RedirectURI
+	}
+	if redirectURI != "" {
+		body["redirect_uri"] = redirectURI
+	}
+	if p.User != nil {
+		body["user_id"] = p.User.ID
+	} else if p.Username != "" {
+		body["username"] = p.Username
+	}
+	if p.Scope != "" {
+		body["scope"] = p.Scope
+	}
+	if p.State != "" {
+		body["state"] = p.State
+	}
+	if p.GrantedScope != "" {
+		body["granted_scope"] = p.GrantedScope
+	}
+	if p.CodeChallenge != "" {
+		body["code_challenge"] = p.CodeChallenge
+	}
+	if p.CodeChallengeMethod != "" {
+		body["code_challenge_method"] = p.CodeChallengeMethod
+	}
+	respBytes := postJSON(t, ts.URL+"/test/authorize", body, http.StatusOK)
+	var resp struct {
+		RedirectURL string `json:"redirect_url"`
+	}
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		t.Fatalf("decode authorize: %v body=%s", err, respBytes)
+	}
+	return resp.RedirectURL
+}
+
+// extractCode pulls the `code` query parameter from a redirect URL.
+// Fails the test if absent.
+func extractCode(t *testing.T, redirectURL string) string {
+	t.Helper()
+	u, err := url.Parse(redirectURL)
+	if err != nil {
+		t.Fatalf("parse redirect %q: %v", redirectURL, err)
+	}
+	c := u.Query().Get("code")
+	if c == "" {
+		t.Fatalf("no code in redirect %q", redirectURL)
+	}
+	return c
+}
+
+// exchangeOpts tunes the token-exchange request beyond the basic
+// (grant_type, code, redirect_uri) trio.
+type exchangeOpts struct {
+	CodeVerifier string // for PKCE
+}
+
+func exchangeCode(t *testing.T, ts *testServer, c *registeredClient, code string, opts ...exchangeOpts) (int, *tokenResponse, []byte) {
+	t.Helper()
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", c.RedirectURI)
+	if len(opts) > 0 && opts[0].CodeVerifier != "" {
+		form.Set("code_verifier", opts[0].CodeVerifier)
+	}
+	return doTokenRequest(t, ts, c, form)
+}
+
+// passwordGrant exchanges username/password for tokens.
+func passwordGrant(t *testing.T, ts *testServer, c *registeredClient, username, password, scope string) (int, *tokenResponse, []byte) {
+	t.Helper()
+	form := url.Values{}
+	form.Set("grant_type", "password")
+	form.Set("username", username)
+	form.Set("password", password)
+	if scope != "" {
+		form.Set("scope", scope)
+	}
+	return doTokenRequest(t, ts, c, form)
+}
+
+// clientCredentialsGrant gets an app-only access token.
+func clientCredentialsGrant(t *testing.T, ts *testServer, c *registeredClient, scope string) (int, *tokenResponse, []byte) {
+	t.Helper()
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	if scope != "" {
+		form.Set("scope", scope)
+	}
+	return doTokenRequest(t, ts, c, form)
+}
+
+// refresh runs grant_type=refresh_token.
+func refresh(t *testing.T, ts *testServer, c *registeredClient, refreshToken string) (int, *tokenResponse, []byte) {
+	t.Helper()
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+	return doTokenRequest(t, ts, c, form)
+}
+
+// doTokenRequest drives /v1/oauth/tokens with the client's configured
+// auth method (basic / form / none).
+func doTokenRequest(t *testing.T, ts *testServer, c *registeredClient, form url.Values) (int, *tokenResponse, []byte) {
+	t.Helper()
+	switch c.TokenEndpointAuthMethod {
+	case oauth.AuthMethodSecretPost:
+		form.Set("client_id", c.Key)
+		form.Set("client_secret", c.Secret)
+	case oauth.AuthMethodNone:
+		form.Set("client_id", c.Key)
+	}
+	req, _ := http.NewRequest("POST", ts.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if c.TokenEndpointAuthMethod == "" || c.TokenEndpointAuthMethod == oauth.AuthMethodSecretBasic {
+		req.SetBasicAuth(c.Key, c.Secret)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("token request: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	var tr tokenResponse
+	_ = json.Unmarshal(body, &tr) // ok if it fails (e.g. error response)
+	return resp.StatusCode, &tr, body
+}
+
+// revokeToken hits /v1/oauth/revoke (RFC 7009 path).
+func revokeToken(t *testing.T, ts *testServer, c *registeredClient, token, hint string) int {
+	t.Helper()
+	form := url.Values{}
+	form.Set("token", token)
+	if hint != "" {
+		form.Set("token_type_hint", hint)
+	}
+	req, _ := http.NewRequest("POST", ts.URL+"/v1/oauth/revoke", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(c.Key, c.Secret)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	resp.Body.Close()
+	return resp.StatusCode
+}
+
+// adminRevoke hits /test/revoke (admin path, no client auth).
+func adminRevoke(t *testing.T, ts *testServer, body map[string]string) {
+	t.Helper()
+	postJSON(t, ts.URL+"/test/revoke", body, http.StatusOK)
+}
+
+// callResource hits /test/resource/<path> with a bearer token.
+func callResource(t *testing.T, ts *testServer, accessToken, path string) (int, http.Header, []byte) {
+	t.Helper()
+	req, _ := http.NewRequest("GET", ts.URL+path, nil)
+	if accessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get resource: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	return resp.StatusCode, resp.Header, body
+}
+
+// userinfo hits /v1/oauth/userinfo.
+func userinfo(t *testing.T, ts *testServer, accessToken string) (int, http.Header, []byte) {
+	t.Helper()
+	req, _ := http.NewRequest("GET", ts.URL+"/v1/oauth/userinfo", nil)
+	if accessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("userinfo: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	return resp.StatusCode, resp.Header, body
+}
+
+// enqueueScript registers script actions for a given client+endpoint.
+// Empty clientID enqueues onto the wildcard queue.
+func enqueueScript(t *testing.T, ts *testServer, clientID, endpoint string, actions ...testmode.Action) {
+	t.Helper()
+	postJSON(t, ts.URL+"/test/scripts", map[string]any{
+		"client_id": clientID,
+		"endpoint":  endpoint,
+		"actions":   actions,
+	}, http.StatusNoContent)
+}
+
+// pkcePair returns a (verifier, S256-challenge) pair suitable for
+// scenario tests. The values are RFC 7636 §4 examples.
+func pkcePair() (verifier, challenge string) {
+	v := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	h := sha256.Sum256([]byte(v))
+	return v, base64.RawURLEncoding.EncodeToString(h[:])
+}
+
+// ----- low-level HTTP helpers -----
+
+func postJSON(t *testing.T, u string, payload any, expectStatus int) []byte {
+	t.Helper()
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	resp, err := http.Post(u, "application/json", bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("POST %s: %v", u, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != expectStatus {
+		t.Fatalf("POST %s: expected %d got %d body=%s", u, expectStatus, resp.StatusCode, body)
+	}
+	return body
+}

--- a/integration/scenario_01_test.go
+++ b/integration/scenario_01_test.go
@@ -1,0 +1,70 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/testmode"
+)
+
+// TestScenario01_StandardOAuthFlow — Phase 1 stub.
+//
+// Phase 1 (#27): asserts the harness boots and the basic helper chain
+// works (register client + user, run /test/health, exercise the
+// recorder + queue plumbing). Full PKCE + S256 + resource round-trip
+// happy-path coverage lands in Phase 2 (#28).
+//
+// Spec: P0 scenario 1 — "Standard Successful OAuth Flow".
+func TestScenario01_StandardOAuthFlow(t *testing.T) {
+	ts := newTestServer(t)
+
+	// /test/health round-trip — the simplest "the server is alive" check.
+	resp, err := http.Get(ts.URL + "/test/health")
+	if err != nil {
+		t.Fatalf("health: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("health expected 200, got %d", resp.StatusCode)
+	}
+	var hb map[string]string
+	json.NewDecoder(resp.Body).Decode(&hb)
+	if hb["status"] != "ok" || hb["mode"] != "test" {
+		t.Fatalf("unexpected health body: %v", hb)
+	}
+
+	// Helper chain: register a client + user, run a password grant, hit
+	// the sample resource. Phase 2 will replace this with the full
+	// authorization-code + PKCE flow.
+	c := registerClient(t, ts, "scn1", "scn1-secret", "https://app.example.com/cb")
+	if c.ID == "" || c.Key != "scn1" {
+		t.Fatalf("unexpected registered client: %+v", c)
+	}
+
+	registerUser(t, ts, "scn1@example.com", "hunter22",
+		userOpts{Email: "scn1@example.com", DisplayName: "Scenario One"})
+
+	status, tok, body := passwordGrant(t, ts, c, "scn1@example.com", "hunter22", "read")
+	if status != http.StatusOK {
+		t.Fatalf("password grant expected 200, got %d body=%s", status, body)
+	}
+	if tok.AccessToken == "" || tok.RefreshToken == "" || tok.TokenType != "Bearer" {
+		t.Fatalf("unexpected token response: %+v", tok)
+	}
+
+	rstatus, _, rbody := callResource(t, ts, tok.AccessToken, "/test/resource/health-check")
+	if rstatus != http.StatusOK {
+		t.Fatalf("resource expected 200, got %d body=%s", rstatus, rbody)
+	}
+
+	// Recorder picked up the token call; this proves BuildTestApp wired
+	// the recorder middleware into the chain correctly.
+	entries := ts.Recorder.Snapshot(testmode.SnapshotFilter{Endpoint: "token"})
+	if len(entries) == 0 {
+		t.Fatalf("expected recorded token request")
+	}
+	if got := entries[0].Headers["Authorization"]; got != "Basic <redacted>" {
+		t.Fatalf("expected Basic <redacted>, got %q", got)
+	}
+}

--- a/integration/testenv_test.go
+++ b/integration/testenv_test.go
@@ -1,0 +1,87 @@
+// Package integration_test holds end-to-end scenario tests that exercise
+// the test-mode server through real HTTP. Test names map 1:1 to the
+// scenario numbers in AuthProxy's integration test requirements doc; see
+// issue #26 for the spec mapping.
+package integration_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/database"
+	"github.com/RichardKnop/go-oauth2-server/health"
+	"github.com/RichardKnop/go-oauth2-server/models"
+	"github.com/RichardKnop/go-oauth2-server/oauth"
+	"github.com/RichardKnop/go-oauth2-server/session"
+	"github.com/RichardKnop/go-oauth2-server/testmode"
+	"github.com/RichardKnop/go-oauth2-server/util/migrations"
+	"github.com/RichardKnop/go-oauth2-server/web"
+	"github.com/gorilla/sessions"
+	"github.com/jinzhu/gorm"
+)
+
+// testServer is the handle a scenario test gets from newTestServer.
+// Boots an in-process --test-mode server backed by an in-memory SQLite
+// database. The Recorder, Queue, and DB are exposed so scenarios can
+// inspect / mutate state without going through HTTP when they need to.
+type testServer struct {
+	URL          string
+	Recorder     *testmode.Recorder
+	Queue        *testmode.ScriptQueue
+	DB           *gorm.DB
+	OauthService *oauth.Service
+	TestService  *testmode.Service
+
+	server *httptest.Server
+}
+
+// newTestServer brings up an in-process test-mode server using
+// testmode.BuildTestApp — same middleware chain and route layout as the
+// runserver --test-mode binary. Each call gets its own fresh in-memory
+// database.
+func newTestServer(t *testing.T) *testServer {
+	t.Helper()
+
+	cnf := testmode.NewConfig(":memory:")
+
+	db, err := database.NewDatabase(cnf)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	if err := migrations.Bootstrap(db); err != nil {
+		t.Fatalf("bootstrap migrations: %v", err)
+	}
+	if err := models.MigrateAll(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if err := testmode.Seed(db); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	healthService := health.NewService(db)
+	oauthService := oauth.NewService(cnf, db)
+	sessionService := session.NewService(cnf, sessions.NewCookieStore([]byte(cnf.Session.Secret)))
+	webService := web.NewService(cnf, oauthService, sessionService)
+	testService := testmode.NewService(cnf, db, oauthService)
+
+	handler := testmode.BuildTestApp(healthService, oauthService, webService, testService)
+	httpSrv := httptest.NewServer(handler)
+
+	ts := &testServer{
+		URL:          httpSrv.URL,
+		Recorder:     testService.Recorder(),
+		Queue:        testService.Queue(),
+		DB:           db,
+		OauthService: oauthService,
+		TestService:  testService,
+		server:       httpSrv,
+	}
+
+	t.Cleanup(func() {
+		httpSrv.Close()
+		db.Close()
+	})
+
+	return ts
+}

--- a/testmode/app.go
+++ b/testmode/app.go
@@ -1,0 +1,55 @@
+package testmode
+
+import (
+	"net/http"
+
+	"github.com/RichardKnop/go-oauth2-server/health"
+	"github.com/RichardKnop/go-oauth2-server/oauth"
+	"github.com/RichardKnop/go-oauth2-server/web"
+	"github.com/gorilla/mux"
+	"github.com/phyber/negroni-gzip/gzip"
+	"github.com/urfave/negroni"
+)
+
+// BuildTestApp assembles the test-mode HTTP handler with the same
+// middleware chain and route layout used by the binary's runserver
+// --test-mode. Both cmd.RunTestServer and the integration test harness
+// build their handlers through this function so the two can't drift.
+//
+// Middleware order:
+//
+//	recovery → logger → recorder → script → gzip → static → router
+//
+// Recorder and script middlewares sit BEFORE gzip so script-injected
+// responses and hijacked connections (drop_connection actions) bypass
+// the gzip writer wrap.
+//
+// Routes:
+//
+//	/v1/...     health
+//	/v1/oauth/* oauth (tokens, introspect, revoke, userinfo)
+//	/web/*      web (login, register, logout, authorize)
+//	/test/*     test-mode control plane (clients, users, scripts, etc.)
+func BuildTestApp(
+	healthService health.ServiceInterface,
+	oauthService oauth.ServiceInterface,
+	webService web.ServiceInterface,
+	testService *Service,
+) http.Handler {
+	app := negroni.New()
+	app.Use(negroni.NewRecovery())
+	app.Use(negroni.NewLogger())
+	app.Use(testService.Middleware())
+	app.Use(testService.ScriptMiddleware())
+	app.Use(gzip.Gzip(gzip.DefaultCompression))
+	app.Use(negroni.NewStatic(http.Dir("public")))
+
+	router := mux.NewRouter()
+	healthService.RegisterRoutes(router, "/v1")
+	oauthService.RegisterRoutes(router, "/v1/oauth")
+	webService.RegisterRoutes(router, "/web")
+	testService.RegisterRoutes(router, "/test")
+
+	app.UseHandler(router)
+	return app
+}


### PR DESCRIPTION
Closes #27. Tracking: #26.

Lays the groundwork for the spec-mapped integration suite (#28–#34 fill in the 30 scenarios).

## Summary

- **`testmode.BuildTestApp`** extracts the test-mode HTTP handler assembly (middleware chain + route mounts) into one place. Both the `runserver --test-mode` binary and the integration tests build their handlers through the same code path. Eliminates the drift risk between `testmode/integration_test.go`'s hand-rolled chain and `cmd/run_test_server.go`'s inline chain.
- **`cmd/run_test_server.go`** is now a thin wrapper: construct services, call `BuildTestApp`, bind, serve. Middleware order is unchanged (`recovery → logger → recorder → script → gzip → static → router`).
- **New `integration/` directory** with the canonical end-to-end suite:
  - `testenv_test.go` — `newTestServer(t)` brings up an in-process `httptest` server backed by in-memory SQLite. Returns a handle exposing URL, recorder, queue, db, oauth service.
  - `helpers_test.go` — ergonomic OAuth-flow helpers (`registerClient`, `registerUser`, `authorize`, `exchangeCode`, `passwordGrant`, `clientCredentialsGrant`, `refresh`, `revokeToken`, `adminRevoke`, `callResource`, `userinfo`, `enqueueScript`, `pkcePair`). Auth-method-aware so scenario tests stay short.
  - `scenario_01_test.go` — Phase 1 stub for `TestScenario01_StandardOAuthFlow`. Boots the harness, exercises the helper chain, asserts recorder middleware is wired. Phase 2 (#28) replaces this with the full PKCE auth-code flow.
  - `binary_smoke_test.go` — `TestBinarySmoke` builds the actual binary, runs `runserver --test-mode --test-port <free>`, polls `/test/health`, asserts clean exit. The only test that exercises `cmd.RunTestServer` + CLI flag plumbing end-to-end.

## Acceptance criteria

- [x] `BuildTestApp` exists and is called by `cmd/run_test_server.go`; the existing `--test-mode` binary still works (covered by binary smoke + manual run).
- [x] `integration/` directory compiles under default `go test ./...`. No build tag.
- [x] `TestScenario01_StandardOAuthFlow` stub passes.
- [x] `TestBinarySmoke` passes on a clean checkout (~2.5s including `go build`).
- [x] Total runtime of `go test ./integration/...` is under 5s.

## What's next

Phase 2 (#28) replaces the scenario 01 stub with the full PKCE auth-code happy path and adds scenarios 6, 9, 19. The helpers in this PR are ergonomic enough that each scenario should be ~30–60 lines of test code.

## Test plan

- [x] `go build ./... && go vet ./... && gofmt -l .` clean
- [x] `go test ./integration/...` — 2 tests pass, ~3s total
- [x] `go test ./testmode/...` — all prior PR subtests still green (BuildTestApp doesn't change observable behavior)
- [ ] (Reviewer) confirm CI green; the new directory runs under the existing `test` job since it has no build tag