### PR TITLE
Phase 3: P0 negatives — scenarios 2, 4, 5, 11

### DIFF
--- a/integration/scenario_02_test.go
+++ b/integration/scenario_02_test.go
@@ -1,0 +1,68 @@
+package integration_test
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/testmode"
+)
+
+// TestScenario02_UserDenial covers the spec's "User Rejects
+// Authorization": deny redirect carries error=access_denied + state, no
+// code, no token exchange happens server-side, and an opportunistic
+// synthetic-code exchange fails.
+//
+// Spec: P0 scenario 2.
+func TestScenario02_UserDenial(t *testing.T) {
+	ts := newTestServer(t)
+
+	c := registerClient(t, ts, "scn02", "scn02-secret", "https://app.example.com/cb")
+	u := registerUser(t, ts, "scn02@example.com", "hunter22")
+
+	const state = "scn02-state-9f1e"
+	redirectURL := authorize(t, ts, "deny", authorizeParams{
+		Client: c,
+		User:   u,
+		Scope:  "read",
+		State:  state,
+	})
+
+	parsed, err := url.Parse(redirectURL)
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	q := parsed.Query()
+	if got := q.Get("error"); got != "access_denied" {
+		t.Fatalf("expected error=access_denied, got %q (full: %s)", got, redirectURL)
+	}
+	if got := q.Get("state"); got != state {
+		t.Fatalf("expected state=%q, got %q", state, got)
+	}
+	if got := q.Get("code"); got != "" {
+		t.Fatalf("deny redirect must not include code, got %q", got)
+	}
+
+	// No token grant happens server-side as a consequence of the deny.
+	if entries := ts.Recorder.Snapshot(testmode.SnapshotFilter{Endpoint: "token"}); len(entries) != 0 {
+		t.Fatalf("expected zero recorded token grants after deny, got %d", len(entries))
+	}
+
+	// A synthetic / replayed code from a malicious client must not work.
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", "00000000-0000-4000-8000-000000000000")
+	form.Set("redirect_uri", c.RedirectURI)
+	req, _ := http.NewRequest("POST", ts.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(c.Key, c.Secret)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("synthetic exchange: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("synthetic-code exchange should fail, got 200")
+	}
+}

--- a/integration/scenario_04_test.go
+++ b/integration/scenario_04_test.go
@@ -1,0 +1,123 @@
+package integration_test
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RichardKnop/go-oauth2-server/models"
+)
+
+// TestScenario04_CallbackSecurity covers the server-side parts of the
+// spec's "Invalid, Missing, or Replayed State" — namely the four
+// guarantees the proxy depends on:
+//
+//   - state is echoed back faithfully, including special characters
+//   - authorization codes are single-use
+//   - redirect_uri at exchange must match the value used at authorize
+//   - expired authorization codes are rejected
+//
+// State validation across users / tenants / connections is proxy-side.
+//
+// Spec: P0 scenario 4.
+func TestScenario04_CallbackSecurity(t *testing.T) {
+	ts := newTestServer(t)
+
+	c := registerClient(t, ts, "scn04", "scn04-secret", "https://app.example.com/cb")
+	u := registerUser(t, ts, "scn04@example.com", "hunter22")
+
+	t.Run("state is echoed faithfully", func(t *testing.T) {
+		states := []string{
+			"plain-state",
+			"with spaces and / slashes",
+			`special !@#$%^&*()_+={}[]|;':",.<>?`,
+			"unicode-✓-and-emoji-🚀",
+		}
+		for _, want := range states {
+			redirectURL := authorize(t, ts, "approve", authorizeParams{
+				Client: c, User: u, Scope: "read", State: want,
+			})
+			parsed, err := url.Parse(redirectURL)
+			if err != nil {
+				t.Fatalf("parse redirect for %q: %v", want, err)
+			}
+			if got := parsed.Query().Get("state"); got != want {
+				t.Fatalf("state mismatch: want %q got %q (url: %s)", want, got, redirectURL)
+			}
+		}
+	})
+
+	t.Run("authorization code is single-use", func(t *testing.T) {
+		redirectURL := authorize(t, ts, "approve", authorizeParams{
+			Client: c, User: u, Scope: "read",
+		})
+		code := extractCode(t, redirectURL)
+
+		// First exchange succeeds.
+		if status, _, body := exchangeCode(t, ts, c, code); status != http.StatusOK {
+			t.Fatalf("first exchange expected 200, got %d body=%s", status, body)
+		}
+		// Second exchange of the same code fails.
+		status, _, body := exchangeCode(t, ts, c, code)
+		if status == http.StatusOK {
+			t.Fatalf("second exchange of same code should fail, got 200 body=%s", body)
+		}
+	})
+
+	t.Run("redirect_uri mismatch at exchange is rejected", func(t *testing.T) {
+		redirectURL := authorize(t, ts, "approve", authorizeParams{
+			Client: c, User: u, Scope: "read",
+		})
+		code := extractCode(t, redirectURL)
+
+		// Hand-roll the exchange with a different redirect_uri than was
+		// used at /test/authorize.
+		form := url.Values{}
+		form.Set("grant_type", "authorization_code")
+		form.Set("code", code)
+		form.Set("redirect_uri", "https://attacker.example.com/cb")
+		req, _ := http.NewRequest("POST", ts.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth(c.Key, c.Secret)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("exchange: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			t.Fatalf("redirect_uri mismatch should reject the exchange, got 200")
+		}
+	})
+
+	t.Run("expired authorization code is rejected", func(t *testing.T) {
+		redirectURL := authorize(t, ts, "approve", authorizeParams{
+			Client: c, User: u, Scope: "read",
+		})
+		code := extractCode(t, redirectURL)
+
+		// Back-date the code so the exchange's expiry check fires. The
+		// auth-code lifetime is config-wide; per-scenario back-dating is
+		// the cleanest way to simulate "the proxy waited too long".
+		expireAuthorizationCode(t, ts, code)
+
+		status, _, body := exchangeCode(t, ts, c, code)
+		if status == http.StatusOK {
+			t.Fatalf("expired code should not exchange, got 200 body=%s", body)
+		}
+	})
+}
+
+func expireAuthorizationCode(t *testing.T, ts *testServer, code string) {
+	t.Helper()
+	res := ts.DB.Model(new(models.OauthAuthorizationCode)).
+		Where("code = ?", code).
+		Update("expires_at", time.Now().UTC().Add(-1*time.Hour))
+	if res.Error != nil {
+		t.Fatalf("expire auth code: %v", res.Error)
+	}
+	if res.RowsAffected != 1 {
+		t.Fatalf("expected to expire 1 auth code row, affected %d", res.RowsAffected)
+	}
+}

--- a/integration/scenario_05_test.go
+++ b/integration/scenario_05_test.go
@@ -1,0 +1,114 @@
+package integration_test
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/testmode"
+)
+
+// TestScenario05_ExchangeFailures covers the spec's "Authorization Code
+// Exchange Failures" — natural failure modes plus scripted bad
+// responses.
+//
+// Spec: P0 scenario 5.
+func TestScenario05_ExchangeFailures(t *testing.T) {
+	ts := newTestServer(t)
+
+	c := registerClient(t, ts, "scn05", "scn05-secret", "https://app.example.com/cb")
+	u := registerUser(t, ts, "scn05@example.com", "hunter22")
+
+	mintCode := func(t *testing.T) string {
+		t.Helper()
+		redirectURL := authorize(t, ts, "approve", authorizeParams{
+			Client: c, User: u, Scope: "read",
+		})
+		return extractCode(t, redirectURL)
+	}
+
+	t.Run("bad client secret -> 401", func(t *testing.T) {
+		code := mintCode(t)
+		form := url.Values{}
+		form.Set("grant_type", "authorization_code")
+		form.Set("code", code)
+		form.Set("redirect_uri", c.RedirectURI)
+		req, _ := http.NewRequest("POST", ts.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth(c.Key, "WRONG-SECRET")
+		resp, _ := http.DefaultClient.Do(req)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("bad secret expected 401, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("redirect_uri mismatch at exchange is rejected", func(t *testing.T) {
+		code := mintCode(t)
+		form := url.Values{}
+		form.Set("grant_type", "authorization_code")
+		form.Set("code", code)
+		form.Set("redirect_uri", "https://other.example.com/cb")
+		req, _ := http.NewRequest("POST", ts.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth(c.Key, c.Secret)
+		resp, _ := http.DefaultClient.Do(req)
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			t.Fatalf("redirect_uri mismatch should reject, got 200")
+		}
+	})
+
+	t.Run("already-used code -> rejected on replay", func(t *testing.T) {
+		code := mintCode(t)
+		if status, _, _ := exchangeCode(t, ts, c, code); status != http.StatusOK {
+			t.Fatalf("first exchange should succeed, got %d", status)
+		}
+		status, _, body := exchangeCode(t, ts, c, code)
+		if status == http.StatusOK {
+			t.Fatalf("replay should fail, got 200 body=%s", body)
+		}
+	})
+
+	t.Run("scripted invalid_grant -> 400", func(t *testing.T) {
+		ts.Queue.Clear("", "")
+		enqueueScript(t, ts, "", "token", testmode.Action{BodyTemplate: "invalid_grant"})
+
+		status, _, body := exchangeCode(t, ts, c, mintCode(t))
+		if status != http.StatusBadRequest {
+			t.Fatalf("scripted invalid_grant should be 400, got %d body=%s", status, body)
+		}
+		if !strings.Contains(string(body), "invalid_grant") {
+			t.Fatalf("expected invalid_grant body, got %s", body)
+		}
+	})
+
+	t.Run("scripted temporarily_unavailable_503 -> 503", func(t *testing.T) {
+		ts.Queue.Clear("", "")
+		enqueueScript(t, ts, "", "token", testmode.Action{BodyTemplate: "temporarily_unavailable_503"})
+
+		status, _, _ := exchangeCode(t, ts, c, mintCode(t))
+		if status != http.StatusServiceUnavailable {
+			t.Fatalf("scripted 503 should be 503, got %d", status)
+		}
+	})
+
+	t.Run("scripted 500 / 502 / 504 reach the client byte-for-byte", func(t *testing.T) {
+		for _, code := range []int{500, 502, 504} {
+			ts.Queue.Clear("", "")
+			body := `{"e":"upstream"}`
+			enqueueScript(t, ts, "", "token", testmode.Action{
+				Status: code,
+				Body:   body,
+			})
+			status, _, gotBody := exchangeCode(t, ts, c, mintCode(t))
+			if status != code {
+				t.Fatalf("scripted %d should be %d, got %d", code, code, status)
+			}
+			if string(gotBody) != body {
+				t.Fatalf("scripted body mismatch for %d: want %q got %q", code, body, gotBody)
+			}
+		}
+	})
+}

--- a/integration/scenario_11_test.go
+++ b/integration/scenario_11_test.go
@@ -1,0 +1,66 @@
+package integration_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestScenario11_ThirdPartyRevocation covers the spec's "User Revokes
+// Access on the Third Party": after a successful flow, the provider
+// admin path is used to revoke the refresh token. The cascade then
+// invalidates the active access token; subsequent refresh and resource
+// calls fail.
+//
+// Spec: P0 scenario 11.
+func TestScenario11_ThirdPartyRevocation(t *testing.T) {
+	ts := newTestServer(t)
+
+	c := registerClient(t, ts, "scn11", "scn11-secret", "https://app.example.com/cb")
+	registerUser(t, ts, "scn11@example.com", "hunter22",
+		userOpts{Email: "scn11@example.com", DisplayName: "Scenario Eleven"})
+
+	_, tok, body := passwordGrant(t, ts, c, "scn11@example.com", "hunter22", "profile")
+	if tok.AccessToken == "" || tok.RefreshToken == "" {
+		t.Fatalf("expected both tokens, body=%s", body)
+	}
+
+	// Sanity: token works at the resource and at userinfo before revocation.
+	if status, _, _ := callResource(t, ts, tok.AccessToken, "/test/resource/foo"); status != http.StatusOK {
+		t.Fatalf("pre-revoke resource expected 200, got %d", status)
+	}
+	if status, _, _ := userinfo(t, ts, tok.AccessToken); status != http.StatusOK {
+		t.Fatalf("pre-revoke userinfo expected 200, got %d", status)
+	}
+
+	// Provider-side revocation: admin path bypasses client auth and
+	// targets the refresh token, which cascades to the access token.
+	adminRevoke(t, ts, map[string]string{"token": tok.RefreshToken})
+
+	t.Run("refresh with revoked RT is rejected", func(t *testing.T) {
+		status, _, body := refresh(t, ts, c, tok.RefreshToken)
+		if status != http.StatusBadRequest {
+			t.Fatalf("expected 400 invalid_grant, got %d body=%s", status, body)
+		}
+		if !strings.Contains(strings.ToLower(string(body)), "revoked") {
+			t.Fatalf("expected error to mention revoked, got %s", body)
+		}
+	})
+
+	t.Run("cascaded access token returns 401 at resource", func(t *testing.T) {
+		status, hdr, body := callResource(t, ts, tok.AccessToken, "/test/resource/foo")
+		if status != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d body=%s", status, body)
+		}
+		if !strings.Contains(hdr.Get("WWW-Authenticate"), `error="invalid_token"`) {
+			t.Fatalf("expected invalid_token in WWW-Authenticate, got %q", hdr.Get("WWW-Authenticate"))
+		}
+	})
+
+	t.Run("cascaded access token returns 401 at userinfo", func(t *testing.T) {
+		status, _, body := userinfo(t, ts, tok.AccessToken)
+		if status != http.StatusUnauthorized {
+			t.Fatalf("expected 401 at userinfo, got %d body=%s", status, body)
+		}
+	})
+}


### PR DESCRIPTION
Closes #29. Tracking: #26.

Four spec-mapped negative-path scenarios. Each leans on the Phase 1 helpers; total 4 new test files / ~370 lines / 17 subtests.

## Scenarios

### `TestScenario02_UserDenial` (P0 #2)

`/test/authorize` with `decision=deny` produces a redirect carrying `error=access_denied` and the original `state`, no `code`. The recorder shows zero token-grant attempts as a consequence. An opportunistic synthetic-code exchange off the deny redirect is rejected.

### `TestScenario04_CallbackSecurity` (P0 #4) — 4 subtests

Server-side guarantees the proxy depends on:

- **state echoes faithfully** across plain, special-character, and unicode inputs
- **authorization codes are single-use** — second exchange fails
- **redirect_uri mismatch at exchange** is rejected (hand-rolled with a different URI than was used at authorize)
- **expired codes are rejected** (back-dated via direct DB write since `Oauth.AuthCodeLifetime` is config-wide and shouldn't be mutated mid-suite)

State validation across users / tenants / connections remains proxy-side and is called out in the test doc comment.

### `TestScenario05_ExchangeFailures` (P0 #5) — 6 subtests

Natural and scripted exchange failures:

| case | expected |
| --- | --- |
| bad client secret | 401 |
| redirect_uri mismatch | rejected |
| already-used code on replay | rejected |
| scripted `body_template: invalid_grant` | 400 with canonical body |
| scripted `body_template: temporarily_unavailable_503` | 503 |
| scripted 500 / 502 / 504 | status AND body reach the client byte-for-byte |

### `TestScenario11_ThirdPartyRevocation` (P0 #11) — 3 subtests

After a password grant, `/test/revoke {token: refresh_token}` (admin path, no client auth) cascades:

- refresh with the revoked RT → 400 with `revoked` in the body
- access token from the chain returns 401 at `/test/resource/foo`, `WWW-Authenticate: ... invalid_token`
- access token returns 401 at `/v1/oauth/userinfo` too

## Test plan

- [x] `go build ./... && go vet ./... && gofmt -l .` clean
- [x] `go test ./integration/...` — 8 scenarios + binary smoke green, ~4.7s total
- [x] All Phase 1 + Phase 2 scenarios still pass