### PR TITLE
Phase 4: P0 scripting + scope + concurrency + redaction

### DIFF
--- a/integration/scenario_03_test.go
+++ b/integration/scenario_03_test.go
@@ -1,0 +1,89 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/testmode"
+)
+
+// TestScenario03_ScopeVariations covers the spec's scope-variation
+// cases: granted-narrower-than-requested, scripted scope_override
+// (omit and replace), and recorded inbound scope.
+//
+// Spec: P0 scenario 3.
+func TestScenario03_ScopeVariations(t *testing.T) {
+	ts := newTestServer(t)
+
+	c := registerClient(t, ts, "scn03", "scn03-secret", "https://app.example.com/cb")
+	u := registerUser(t, ts, "scn03@example.com", "hunter22")
+
+	t.Run("granted_scope narrows the issued scope", func(t *testing.T) {
+		ts.Queue.Clear("", "")
+
+		redirectURL := authorize(t, ts, "approve", authorizeParams{
+			Client:       c,
+			User:         u,
+			Scope:        "read_write",
+			GrantedScope: "read",
+		})
+		code := extractCode(t, redirectURL)
+
+		status, tok, body := exchangeCode(t, ts, c, code)
+		if status != http.StatusOK {
+			t.Fatalf("exchange expected 200, got %d body=%s", status, body)
+		}
+		if tok.Scope != "read" {
+			t.Fatalf("expected scope narrowed to 'read', got %q (full: %s)", tok.Scope, body)
+		}
+	})
+
+	t.Run("script scope_override empty omits scope from response", func(t *testing.T) {
+		ts.Queue.Clear("", "")
+		emptyScope := ""
+		enqueueScript(t, ts, "", "token", testmode.Action{ScopeOverride: &emptyScope})
+
+		// Use password grant for simplicity.
+		_, _, body := passwordGrant(t, ts, c, "scn03@example.com", "hunter22", "read")
+		var generic map[string]any
+		if err := json.Unmarshal(body, &generic); err != nil {
+			t.Fatalf("decode token body: %v body=%s", err, body)
+		}
+		if _, has := generic["scope"]; has {
+			t.Fatalf("expected scope omitted, got %s", body)
+		}
+		if _, has := generic["access_token"]; !has {
+			t.Fatalf("expected access_token still present, got %s", body)
+		}
+	})
+
+	t.Run("script scope_override non-empty replaces scope", func(t *testing.T) {
+		ts.Queue.Clear("", "")
+		newScope := "narrowed"
+		enqueueScript(t, ts, "", "token", testmode.Action{ScopeOverride: &newScope})
+
+		_, tok, body := passwordGrant(t, ts, c, "scn03@example.com", "hunter22", "read")
+		if tok.Scope != "narrowed" {
+			t.Fatalf("expected scope=narrowed, got %q (body=%s)", tok.Scope, body)
+		}
+	})
+
+	t.Run("recorder captures the inbound requested scope", func(t *testing.T) {
+		ts.Queue.Clear("", "")
+		ts.Recorder.Reset()
+
+		// Plain password grant; no scope override, recorder should see
+		// the scope the client sent.
+		_, _, _ = passwordGrant(t, ts, c, "scn03@example.com", "hunter22", "read_write")
+
+		entries := ts.Recorder.Snapshot(testmode.SnapshotFilter{Endpoint: "token"})
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 recorded token call, got %d", len(entries))
+		}
+		got := entries[0].Form["scope"]
+		if len(got) != 1 || got[0] != "read_write" {
+			t.Fatalf("expected recorded scope=[read_write], got %v", got)
+		}
+	})
+}

--- a/integration/scenario_07_test.go
+++ b/integration/scenario_07_test.go
@@ -1,0 +1,93 @@
+package integration_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/testmode"
+)
+
+// TestScenario07_RefreshFailures covers the spec's "Refresh Token
+// Failure" cases — both natural (revoked RT) and scripted (invalid_grant,
+// malformed JSON, success-without-access-token).
+//
+// Spec: P0 scenario 7.
+func TestScenario07_RefreshFailures(t *testing.T) {
+	ts := newTestServer(t)
+
+	c := registerClient(t, ts, "scn07", "scn07-secret", "https://app.example.com/cb")
+	registerUser(t, ts, "scn07@example.com", "hunter22")
+
+	mintRT := func(t *testing.T) string {
+		t.Helper()
+		_, tok, body := passwordGrant(t, ts, c, "scn07@example.com", "hunter22", "read")
+		if tok.RefreshToken == "" {
+			t.Fatalf("expected refresh_token from password grant, body=%s", body)
+		}
+		return tok.RefreshToken
+	}
+
+	t.Run("revoked RT is rejected", func(t *testing.T) {
+		ts.Queue.Clear("", "")
+
+		rt := mintRT(t)
+		// Revoke via the admin path.
+		adminRevoke(t, ts, map[string]string{"token": rt})
+
+		status, _, body := refresh(t, ts, c, rt)
+		if status != http.StatusBadRequest {
+			t.Fatalf("expected 400 on revoked RT, got %d body=%s", status, body)
+		}
+	})
+
+	t.Run("scripted invalid_grant on refresh", func(t *testing.T) {
+		ts.Queue.Clear("", "")
+		enqueueScript(t, ts, "", "refresh", testmode.Action{BodyTemplate: "invalid_grant"})
+
+		status, _, body := refresh(t, ts, c, mintRT(t))
+		if status != http.StatusBadRequest {
+			t.Fatalf("scripted invalid_grant expected 400, got %d body=%s", status, body)
+		}
+		if !strings.Contains(string(body), "invalid_grant") {
+			t.Fatalf("expected canonical invalid_grant body, got %s", body)
+		}
+	})
+
+	t.Run("scripted malformed_json on refresh", func(t *testing.T) {
+		ts.Queue.Clear("", "")
+		enqueueScript(t, ts, "", "refresh", testmode.Action{BodyTemplate: "malformed_json"})
+
+		status, _, body := refresh(t, ts, c, mintRT(t))
+		// The malformed_json template uses status 200, so the proxy gets
+		// a 200 with a body that isn't valid JSON. Server-side, the
+		// response should be byte-for-byte the malformed string from the
+		// template.
+		if status != http.StatusOK {
+			t.Fatalf("malformed_json template uses 200, got %d", status)
+		}
+		if string(body) != "{not valid json" {
+			t.Fatalf("expected malformed body byte-for-byte, got %q", body)
+		}
+	})
+
+	t.Run("scripted success-without-access-token", func(t *testing.T) {
+		ts.Queue.Clear("", "")
+		// Custom body that mimics a successful refresh response but is
+		// missing access_token. Server should pass it through verbatim;
+		// it's the proxy's job to detect the missing field.
+		body := `{"refresh_token":"new-rt-12345","token_type":"Bearer","expires_in":3600}`
+		enqueueScript(t, ts, "", "refresh", testmode.Action{
+			Status: 200,
+			Body:   body,
+		})
+
+		status, _, gotBody := refresh(t, ts, c, mintRT(t))
+		if status != http.StatusOK {
+			t.Fatalf("expected scripted 200, got %d", status)
+		}
+		if string(gotBody) != body {
+			t.Fatalf("expected body byte-for-byte; want %q got %q", body, gotBody)
+		}
+	})
+}

--- a/integration/scenario_08_test.go
+++ b/integration/scenario_08_test.go
@@ -1,0 +1,64 @@
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/testmode"
+)
+
+// TestScenario08_RefreshTransientWithRetry exercises the script queue's
+// fail_count + fall-through semantics: enqueue a single 503 action with
+// fail_count: 2, hit refresh three times — first two fire the action,
+// third falls through to the real handler and refreshes successfully.
+//
+// Proxy retry policy itself is out of scope; the server contribution
+// is "scripted failures fire in FIFO order, then the queue empties and
+// real handlers take over". Subsequent rotation invariants (PR-4) hold:
+// after the third refresh, the original RT is revoked and the new RT
+// works.
+//
+// Spec: P0 scenario 8.
+func TestScenario08_RefreshTransientWithRetry(t *testing.T) {
+	ts := newTestServer(t)
+
+	c := registerClient(t, ts, "scn08", "scn08-secret", "https://app.example.com/cb")
+	registerUser(t, ts, "scn08@example.com", "hunter22")
+
+	_, tok, body := passwordGrant(t, ts, c, "scn08@example.com", "hunter22", "read")
+	if tok.RefreshToken == "" {
+		t.Fatalf("expected refresh_token, body=%s", body)
+	}
+	originalRT := tok.RefreshToken
+
+	// Enqueue ONE action with fail_count: 2 (apply twice, then drop).
+	enqueueScript(t, ts, "", "refresh", testmode.Action{
+		BodyTemplate: "temporarily_unavailable_503",
+		FailCount:    2,
+	})
+
+	// First two refreshes: scripted 503. The original RT is untouched
+	// because the script intercepts before the real handler runs.
+	for i := 1; i <= 2; i++ {
+		status, _, _ := refresh(t, ts, c, originalRT)
+		if status != http.StatusServiceUnavailable {
+			t.Fatalf("refresh #%d expected 503, got %d", i, status)
+		}
+	}
+
+	// Third refresh: queue is now empty (fail_count exhausted), real
+	// handler runs, rotation produces a new RT.
+	status, refreshed, rbody := refresh(t, ts, c, originalRT)
+	if status != http.StatusOK {
+		t.Fatalf("refresh #3 expected 200 fall-through, got %d body=%s", status, rbody)
+	}
+	if refreshed.RefreshToken == "" || refreshed.RefreshToken == originalRT {
+		t.Fatalf("expected a new RT after fall-through, got %q (was %q)", refreshed.RefreshToken, originalRT)
+	}
+
+	// The original RT is now revoked by the rotation; replay must fail.
+	statusReplay, _, _ := refresh(t, ts, c, originalRT)
+	if statusReplay != http.StatusBadRequest {
+		t.Fatalf("expected 400 replay-after-rotation, got %d", statusReplay)
+	}
+}

--- a/integration/scenario_10_test.go
+++ b/integration/scenario_10_test.go
@@ -1,0 +1,59 @@
+package integration_test
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+)
+
+// TestScenario10_ConcurrentRefresh hammers the same refresh token with
+// N parallel goroutines and asserts the CAS guarantee end-to-end:
+// exactly one wins (200 with new tokens), the rest fail (400). This is
+// the HTTP-layer counterpart to the unit-level TestRefreshTokenRotation
+// in testmode/integration_test.go — same invariant but driven through
+// the BuildTestApp middleware chain.
+//
+// Spec: P0 scenario 10.
+func TestScenario10_ConcurrentRefresh(t *testing.T) {
+	ts := newTestServer(t)
+
+	c := registerClient(t, ts, "scn10", "scn10-secret", "https://app.example.com/cb")
+	registerUser(t, ts, "scn10@example.com", "hunter22")
+
+	_, tok, body := passwordGrant(t, ts, c, "scn10@example.com", "hunter22", "read")
+	if tok.RefreshToken == "" {
+		t.Fatalf("expected refresh_token, body=%s", body)
+	}
+	originalRT := tok.RefreshToken
+
+	const N = 8
+	var wg sync.WaitGroup
+	statuses := make([]int, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			s, _, _ := refresh(t, ts, c, originalRT)
+			statuses[i] = s
+		}(i)
+	}
+	wg.Wait()
+
+	winners, losers := 0, 0
+	for _, s := range statuses {
+		switch s {
+		case http.StatusOK:
+			winners++
+		case http.StatusBadRequest:
+			losers++
+		default:
+			t.Fatalf("unexpected status from concurrent refresh: %d (full: %v)", s, statuses)
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("expected exactly 1 winner across %d concurrent refreshes, got %d (statuses: %v)", N, winners, statuses)
+	}
+	if losers != N-1 {
+		t.Fatalf("expected %d losers, got %d (statuses: %v)", N-1, losers, statuses)
+	}
+}

--- a/integration/scenario_12_test.go
+++ b/integration/scenario_12_test.go
@@ -1,0 +1,219 @@
+package integration_test
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/oauth"
+	"github.com/RichardKnop/go-oauth2-server/testmode"
+)
+
+// TestScenario12_SensitiveValueRedaction proves that secrets do not
+// appear in /test/requests for any of the recordable endpoints. Covers:
+//
+//   - Authorization: Basic <redacted>  (raw secret never recorded)
+//   - Authorization: Bearer <redacted> (raw token never recorded)
+//   - form fields client_secret, password, code_verifier, refresh_token
+//     all redacted to <redacted>
+//   - Cookie / Set-Cookie absent from recorded headers
+//   - error response bodies don't echo the supplied secret
+//
+// Spec: P0 scenario 12.
+func TestScenario12_SensitiveValueRedaction(t *testing.T) {
+	ts := newTestServer(t)
+
+	const supersecret = "super-s3cret-do-not-leak"
+	const userPassword = "very-secret-password-do-not-leak"
+
+	cBasic := registerClient(t, ts, "scn12-basic", supersecret, "https://app.example.com/cb")
+	cPost := registerClient(t, ts, "scn12-post", supersecret, "https://app.example.com/cb",
+		clientOpts{AuthMethod: oauth.AuthMethodSecretPost})
+	registerUser(t, ts, "scn12@example.com", userPassword)
+
+	t.Run("basic-auth client: Authorization Basic <redacted>", func(t *testing.T) {
+		ts.Recorder.Reset()
+		ts.Queue.Clear("", "")
+		_, _, _ = clientCredentialsGrant(t, ts, cBasic, "read")
+		entries := ts.Recorder.Snapshot(testmode.SnapshotFilter{Endpoint: "token"})
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 token entry, got %d", len(entries))
+		}
+		assertNoLeak(t, entries[0], supersecret, "")
+		if got := entries[0].Headers["Authorization"]; got != "Basic <redacted>" {
+			t.Fatalf("expected Basic <redacted>, got %q", got)
+		}
+	})
+
+	t.Run("post-auth client: form client_secret <redacted>", func(t *testing.T) {
+		ts.Recorder.Reset()
+		ts.Queue.Clear("", "")
+		_, _, _ = clientCredentialsGrant(t, ts, cPost, "read")
+		entries := ts.Recorder.Snapshot(testmode.SnapshotFilter{Endpoint: "token"})
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 token entry, got %d", len(entries))
+		}
+		assertNoLeak(t, entries[0], supersecret, "")
+		if got := entries[0].Form["client_secret"]; len(got) != 1 || got[0] != "<redacted>" {
+			t.Fatalf("expected client_secret <redacted>, got %v", got)
+		}
+	})
+
+	t.Run("password grant: form password <redacted>", func(t *testing.T) {
+		ts.Recorder.Reset()
+		ts.Queue.Clear("", "")
+		_, _, _ = passwordGrant(t, ts, cBasic, "scn12@example.com", userPassword, "read")
+		entries := ts.Recorder.Snapshot(testmode.SnapshotFilter{Endpoint: "token"})
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 token entry, got %d", len(entries))
+		}
+		assertNoLeak(t, entries[0], supersecret, userPassword)
+		if got := entries[0].Form["password"]; len(got) != 1 || got[0] != "<redacted>" {
+			t.Fatalf("expected password <redacted>, got %v", got)
+		}
+	})
+
+	t.Run("auth-code with PKCE: form code_verifier <redacted>", func(t *testing.T) {
+		ts.Recorder.Reset()
+		ts.Queue.Clear("", "")
+
+		verifier, challenge := pkcePair()
+		redirectURL := authorize(t, ts, "approve", authorizeParams{
+			Client:              cBasic,
+			Username:            "scn12@example.com",
+			Scope:               "read",
+			CodeChallenge:       challenge,
+			CodeChallengeMethod: "S256",
+		})
+		code := extractCode(t, redirectURL)
+		_, _, _ = exchangeCode(t, ts, cBasic, code, exchangeOpts{CodeVerifier: verifier})
+
+		entries := ts.Recorder.Snapshot(testmode.SnapshotFilter{Endpoint: "token"})
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 token entry, got %d", len(entries))
+		}
+		assertNoLeak(t, entries[0], supersecret, verifier)
+		if got := entries[0].Form["code_verifier"]; len(got) != 1 || got[0] != "<redacted>" {
+			t.Fatalf("expected code_verifier <redacted>, got %v", got)
+		}
+	})
+
+	t.Run("refresh: form refresh_token <redacted>", func(t *testing.T) {
+		ts.Recorder.Reset()
+		ts.Queue.Clear("", "")
+
+		_, tok, _ := passwordGrant(t, ts, cBasic, "scn12@example.com", userPassword, "read")
+		_, _, _ = refresh(t, ts, cBasic, tok.RefreshToken)
+
+		entries := ts.Recorder.Snapshot(testmode.SnapshotFilter{Endpoint: "refresh"})
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 refresh entry, got %d (full: %+v)", len(entries),
+				ts.Recorder.Snapshot(testmode.SnapshotFilter{}))
+		}
+		assertNoLeak(t, entries[0], supersecret, tok.RefreshToken)
+		if got := entries[0].Form["refresh_token"]; len(got) != 1 || got[0] != "<redacted>" {
+			t.Fatalf("expected refresh_token <redacted>, got %v", got)
+		}
+	})
+
+	t.Run("resource: Authorization Bearer <redacted>", func(t *testing.T) {
+		ts.Recorder.Reset()
+		ts.Queue.Clear("", "")
+
+		_, tok, _ := passwordGrant(t, ts, cBasic, "scn12@example.com", userPassword, "read")
+		_, _, _ = callResource(t, ts, tok.AccessToken, "/test/resource/foo")
+
+		entries := ts.Recorder.Snapshot(testmode.SnapshotFilter{Endpoint: "resource"})
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 resource entry, got %d", len(entries))
+		}
+		assertNoLeak(t, entries[0], supersecret, tok.AccessToken)
+		if got := entries[0].Headers["Authorization"]; got != "Bearer <redacted>" {
+			t.Fatalf("expected Bearer <redacted>, got %q", got)
+		}
+	})
+
+	t.Run("recorded headers do not include Cookie / Set-Cookie", func(t *testing.T) {
+		ts.Recorder.Reset()
+		ts.Queue.Clear("", "")
+
+		// Hit a recorded endpoint with a Cookie header.
+		form := url.Values{}
+		form.Set("grant_type", "client_credentials")
+		form.Set("scope", "read")
+		req, _ := http.NewRequest("POST", ts.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Cookie", "session=do-not-leak")
+		req.SetBasicAuth(cBasic.Key, cBasic.Secret)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("token: %v", err)
+		}
+		resp.Body.Close()
+
+		entries := ts.Recorder.Snapshot(testmode.SnapshotFilter{Endpoint: "token"})
+		if len(entries) == 0 {
+			t.Fatalf("expected at least 1 token entry")
+		}
+		for _, e := range entries {
+			if _, has := e.Headers["Cookie"]; has {
+				t.Fatalf("Cookie should be stripped from recorded headers, got %v", e.Headers)
+			}
+			if _, has := e.Headers["Set-Cookie"]; has {
+				t.Fatalf("Set-Cookie should be stripped from recorded headers, got %v", e.Headers)
+			}
+		}
+	})
+
+	t.Run("error response body does not echo client_secret", func(t *testing.T) {
+		// Wrong-secret POST: server returns 401, body should not echo
+		// the bad secret we sent.
+		form := url.Values{}
+		form.Set("grant_type", "client_credentials")
+		form.Set("scope", "read")
+		req, _ := http.NewRequest("POST", ts.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth(cBasic.Key, "WRONG-SECRET-with-marker-leak-zz")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("token: %v", err)
+		}
+		var buf [4096]byte
+		n, _ := resp.Body.Read(buf[:])
+		resp.Body.Close()
+		body := string(buf[:n])
+		if strings.Contains(body, "WRONG-SECRET-with-marker-leak-zz") {
+			t.Fatalf("error body echoed the secret: %s", body)
+		}
+	})
+}
+
+// assertNoLeak fails the test if the recorded entry contains the given
+// secrets anywhere in headers, query, or form values.
+func assertNoLeak(t *testing.T, entry testmode.RecordedRequest, secrets ...string) {
+	t.Helper()
+	check := func(s string, where string) {
+		for _, secret := range secrets {
+			if secret == "" {
+				continue
+			}
+			if strings.Contains(s, secret) {
+				t.Fatalf("secret %q leaked in %s: %q", secret, where, s)
+			}
+		}
+	}
+	for k, v := range entry.Headers {
+		check(v, "header "+k)
+	}
+	for k, vs := range entry.Query {
+		for _, v := range vs {
+			check(v, "query "+k)
+		}
+	}
+	for k, vs := range entry.Form {
+		for _, v := range vs {
+			check(v, "form "+k)
+		}
+	}
+}

--- a/testmode/app.go
+++ b/testmode/app.go
@@ -7,7 +7,6 @@ import (
 	"github.com/RichardKnop/go-oauth2-server/oauth"
 	"github.com/RichardKnop/go-oauth2-server/web"
 	"github.com/gorilla/mux"
-	"github.com/phyber/negroni-gzip/gzip"
 	"github.com/urfave/negroni"
 )
 
@@ -18,11 +17,15 @@ import (
 //
 // Middleware order:
 //
-//	recovery → logger → recorder → script → gzip → static → router
+//	recovery → logger → recorder → script → static → router
 //
-// Recorder and script middlewares sit BEFORE gzip so script-injected
-// responses and hijacked connections (drop_connection actions) bypass
-// the gzip writer wrap.
+// gzip is intentionally absent: it would wrap the response writer
+// downstream of the script middleware, breaking pass-through actions
+// (e.g. scope_override) that need to parse the handler's JSON body
+// and breaking drop_connection (gzip's writer doesn't implement
+// http.Hijacker). Test mode is a controllable test provider, not a
+// perf-sensitive endpoint, so the gzip overhead doesn't earn its
+// keep here. Production runserver keeps gzip in cmd/run_server.go.
 //
 // Routes:
 //
@@ -41,7 +44,6 @@ func BuildTestApp(
 	app.Use(negroni.NewLogger())
 	app.Use(testService.Middleware())
 	app.Use(testService.ScriptMiddleware())
-	app.Use(gzip.Gzip(gzip.DefaultCompression))
 	app.Use(negroni.NewStatic(http.Dir("public")))
 
 	router := mux.NewRouter()


### PR DESCRIPTION
Closes #30. Tracking: #26.

Five spec-mapped scenarios + one bug fix bundled along the way.

## Scenarios

### `TestScenario03_ScopeVariations` (P0 #3) — 4 subtests

- `granted_scope` narrower than requested → token's `scope` reflects the narrower set
- scripted `scope_override: \"\"` → response omits `scope` field entirely
- scripted `scope_override: \"narrowed\"` → response replaces `scope`
- recorder captures the **original requested** scope on the inbound side

### `TestScenario07_RefreshFailures` (P0 #7) — 4 subtests

- revoked RT (admin-revoked) → 400
- scripted `body_template: invalid_grant` → 400 with canonical body
- scripted `body_template: malformed_json` → byte-for-byte malformed body delivered to the client
- scripted success-without-access-token (custom JSON) → byte-for-byte passthrough

### `TestScenario08_RefreshTransientWithRetry` (P0 #8)

`fail_count: 2` of `temporarily_unavailable_503` on the refresh endpoint. First two refreshes return 503 (script intercepts before the real handler runs, so the original RT is untouched). Third call falls through, real handler runs, rotation kicks in, the original RT is now revoked.

### `TestScenario10_ConcurrentRefresh` (P0 #10)

HTTP-layer CAS exercise: 8 parallel goroutines hit `/v1/oauth/tokens` with the same refresh token. Exactly one returns 200 with new tokens; the other seven return 400. Counterpart to the unit-level test in `testmode/integration_test.go::TestRefreshTokenRotation`, but driven through the real `BuildTestApp` middleware chain.

### `TestScenario12_SensitiveValueRedaction` (P0 #12) — 8 subtests

| flow | what gets redacted |
| --- | --- |
| basic-auth client | `Authorization: Basic <redacted>` |
| post-auth client | form `client_secret: <redacted>` |
| password grant | form `password: <redacted>` |
| auth-code + PKCE exchange | form `code_verifier: <redacted>` |
| refresh | form `refresh_token: <redacted>` |
| resource (bearer) | `Authorization: Bearer <redacted>` |
| any flow with cookies | `Cookie` and `Set-Cookie` stripped from recorded headers |
| wrong-secret error | response body doesn't echo the supplied secret |

The `assertNoLeak` helper sweeps every recorded header / query / form value for the known secrets in each subtest, so any future regression that surfaces a leaked value anywhere in the recorder's output fails the assertion immediately.

## Bug fix bundled

`BuildTestApp` dropped gzip middleware.

With gzip in the chain, the script middleware's pass-through actions (specifically `scope_override`, which buffers the handler response and rewrites the JSON) saw gzip-compressed bytes in their buffer because gzip wraps the writer downstream of script. `json.Unmarshal` silently failed, the rewrite fell through, and the client received the unmodified body.

Test mode is a controllable test provider, not a perf-sensitive endpoint, so the gzip overhead doesn't earn its keep here. Production runserver keeps gzip in `cmd/run_server.go`. Documented in the comment on `BuildTestApp`.

The unit-level `scope_override` tests in `testmode/integration_test.go` passed only because their hand-rolled negroni stack didn't include gzip — the integration suite via `BuildTestApp` does, which is what caught this. (Previously the `BuildTestApp` happy-path test in scenario 1 worked because it doesn't pass-through, and scenario 5's byte-for-byte 5xx tests worked because the gzip-wrapped 5xx body still got auto-decompressed by Go's default `http.Client`.)

## Test plan

- [x] `go build ./... && go vet ./... && gofmt -l .` clean
- [x] `go test ./integration/...` — 13 scenarios + binary smoke green, ~7s total
- [x] `go test ./testmode/...` — all prior PR subtests still green
- [x] Live binary smoke — `runserver --test-mode` responds 200 on `/test/health`