### PR TITLE
Phase 5: P1 robustness — scenarios 13-18

### DIFF
--- a/integration/scenario_13_test.go
+++ b/integration/scenario_13_test.go
@@ -1,0 +1,45 @@
+package integration_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/testmode"
+)
+
+// TestScenario13_NoRefreshToken covers the spec's "Successful Flow
+// Without Refresh Token". Some real providers omit refresh_token from
+// their token response (e.g. for short-lived public-client flows). The
+// proxy needs to handle that path; the server's contribution is being
+// able to produce such a response on demand.
+//
+// Spec: P1 scenario 13.
+func TestScenario13_NoRefreshToken(t *testing.T) {
+	ts := newTestServer(t)
+	c := registerClient(t, ts, "scn13", "scn13-secret", "https://app.example.com/cb")
+
+	const scriptedBody = `{"access_token":"sole-access-token","token_type":"Bearer","expires_in":3600,"scope":"read"}`
+	enqueueScript(t, ts, "", "token", testmode.Action{Status: 200, Body: scriptedBody})
+
+	status, _, body := clientCredentialsGrant(t, ts, c, "read")
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", status, body)
+	}
+	if string(body) != scriptedBody {
+		t.Fatalf("body should be byte-for-byte the scripted body. want %q got %q", scriptedBody, body)
+	}
+	if strings.Contains(string(body), "refresh_token") {
+		t.Fatalf("body should not contain refresh_token, got %q", body)
+	}
+
+	// Recorder still picks up the request (the scripter doesn't bypass
+	// the recorder, which is mounted earlier in the chain).
+	entries := ts.Recorder.Snapshot(testmode.SnapshotFilter{Endpoint: "token"})
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 recorded token request, got %d", len(entries))
+	}
+	if entries[0].ClientID != "scn13" {
+		t.Fatalf("expected recorded client_id=scn13, got %q", entries[0].ClientID)
+	}
+}

--- a/integration/scenario_14_test.go
+++ b/integration/scenario_14_test.go
@@ -1,0 +1,120 @@
+package integration_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/oauth"
+)
+
+// TestScenario14_PKCEValidation walks through every PKCE branch the
+// proxy may exercise:
+//
+//   - S256 happy path: matching verifier → 200
+//   - S256 mismatch: wrong verifier → 400
+//   - missing verifier when challenge is stored → 400
+//   - plain method works
+//   - none-client (strict PKCE) without challenge at authorize → 400
+//   - unknown method (S512) at authorize → 400
+//
+// Spec: P1 scenario 14.
+func TestScenario14_PKCEValidation(t *testing.T) {
+	ts := newTestServer(t)
+
+	c := registerClient(t, ts, "scn14", "scn14-secret", "https://app.example.com/cb")
+	registerUser(t, ts, "scn14@example.com", "hunter22")
+
+	verifier, challenge := pkcePair()
+
+	authWithChallenge := func(t *testing.T, method string) string {
+		t.Helper()
+		redirectURL := authorize(t, ts, "approve", authorizeParams{
+			Client:              c,
+			Username:            "scn14@example.com",
+			Scope:               "read",
+			CodeChallenge:       challenge,
+			CodeChallengeMethod: method,
+		})
+		return extractCode(t, redirectURL)
+	}
+
+	t.Run("S256 happy path", func(t *testing.T) {
+		code := authWithChallenge(t, "S256")
+		status, tok, body := exchangeCode(t, ts, c, code, exchangeOpts{CodeVerifier: verifier})
+		if status != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", status, body)
+		}
+		if tok.AccessToken == "" {
+			t.Fatalf("missing access token: %s", body)
+		}
+	})
+
+	t.Run("S256 mismatch is rejected", func(t *testing.T) {
+		code := authWithChallenge(t, "S256")
+		status, _, body := exchangeCode(t, ts, c, code, exchangeOpts{CodeVerifier: "WRONG-VERIFIER"})
+		if status != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d body=%s", status, body)
+		}
+		if !strings.Contains(string(body), "code_verifier") {
+			t.Fatalf("error should mention code_verifier, got %s", body)
+		}
+	})
+
+	t.Run("missing verifier when challenge is stored", func(t *testing.T) {
+		code := authWithChallenge(t, "S256")
+		status, _, body := exchangeCode(t, ts, c, code) // no opts → no verifier
+		if status != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d body=%s", status, body)
+		}
+	})
+
+	t.Run("plain method", func(t *testing.T) {
+		// For plain, challenge == verifier.
+		redirectURL := authorize(t, ts, "approve", authorizeParams{
+			Client:              c,
+			Username:            "scn14@example.com",
+			Scope:               "read",
+			CodeChallenge:       verifier,
+			CodeChallengeMethod: "plain",
+		})
+		code := extractCode(t, redirectURL)
+		status, _, body := exchangeCode(t, ts, c, code, exchangeOpts{CodeVerifier: verifier})
+		if status != http.StatusOK {
+			t.Fatalf("expected 200 for plain match, got %d body=%s", status, body)
+		}
+	})
+
+	t.Run("none client without challenge at authorize is rejected", func(t *testing.T) {
+		pub := registerClient(t, ts, "scn14-pub", "", "https://app.example.com/cb",
+			clientOpts{AuthMethod: oauth.AuthMethodNone})
+		if !pub.RequirePKCE {
+			t.Fatalf("none clients should auto-set require_pkce, got %+v", pub)
+		}
+
+		// Hand-roll the authorize request because the helper would 200 on
+		// success; a strict-PKCE no-challenge authorize should fail with 400.
+		buf := strings.NewReader(`{"client_id":"scn14-pub","username":"scn14@example.com","redirect_uri":"https://app.example.com/cb","scope":"read","decision":"approve"}`)
+		resp, err := http.Post(ts.URL+"/test/authorize", "application/json", buf)
+		if err != nil {
+			t.Fatalf("authorize: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected 400 for none-client without challenge, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("unknown method (S512) at authorize is rejected", func(t *testing.T) {
+		buf := strings.NewReader(`{"client_id":"scn14","username":"scn14@example.com","redirect_uri":"https://app.example.com/cb","scope":"read","decision":"approve","code_challenge":"` + challenge + `","code_challenge_method":"S512"}`)
+		resp, err := http.Post(ts.URL+"/test/authorize", "application/json", buf)
+		if err != nil {
+			t.Fatalf("authorize: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected 400 for unknown method, got %d", resp.StatusCode)
+		}
+	})
+
+}

--- a/integration/scenario_15_test.go
+++ b/integration/scenario_15_test.go
@@ -1,0 +1,64 @@
+package integration_test
+
+import (
+	"net/url"
+	"testing"
+)
+
+// TestScenario15_CallbackBothCodeAndError covers the server's
+// contribution to the spec's "Callback Contains Both Code and Error":
+// the test-mode authorize endpoint can produce both shapes, so a proxy
+// test harness can stitch them into a single malicious URL and verify
+// the proxy rejects it.
+//
+// PROXY-SIDE: deciding what to do when a real callback URL contains
+// both `code` and `error` is the proxy's responsibility — not the
+// provider's — and is therefore not covered here. See
+// docs/integration_test_gaps.md row "scenario-15".
+//
+// Spec: P1 scenario 15.
+func TestScenario15_CallbackBothCodeAndError(t *testing.T) {
+	ts := newTestServer(t)
+	c := registerClient(t, ts, "scn15", "scn15-secret", "https://app.example.com/cb")
+	u := registerUser(t, ts, "scn15@example.com", "hunter22")
+
+	// Approve produces a redirect with code + state.
+	approve := authorize(t, ts, "approve", authorizeParams{
+		Client: c, User: u, Scope: "read", State: "scn15",
+	})
+	approveU, err := url.Parse(approve)
+	if err != nil {
+		t.Fatalf("parse approve: %v", err)
+	}
+	if approveU.Query().Get("code") == "" {
+		t.Fatalf("approve must include code, got %s", approve)
+	}
+	if approveU.Query().Get("state") != "scn15" {
+		t.Fatalf("approve must echo state, got %q", approveU.Query().Get("state"))
+	}
+	if approveU.Query().Get("error") != "" {
+		t.Fatalf("approve must not include error, got %s", approve)
+	}
+
+	// Deny produces a redirect with error + state, no code.
+	deny := authorize(t, ts, "deny", authorizeParams{
+		Client: c, User: u, Scope: "read", State: "scn15",
+	})
+	denyU, err := url.Parse(deny)
+	if err != nil {
+		t.Fatalf("parse deny: %v", err)
+	}
+	if got := denyU.Query().Get("error"); got != "access_denied" {
+		t.Fatalf("deny must include error=access_denied, got %q", got)
+	}
+	if denyU.Query().Get("state") != "scn15" {
+		t.Fatalf("deny must echo state, got %q", denyU.Query().Get("state"))
+	}
+	if got := denyU.Query().Get("code"); got != "" {
+		t.Fatalf("deny must not include code, got %q", got)
+	}
+
+	// At this point both shapes have been demonstrated; a proxy test
+	// can construct the malicious URL by combining the two as a
+	// crafted callback. The server's job ends here.
+}

--- a/integration/scenario_16_test.go
+++ b/integration/scenario_16_test.go
@@ -1,0 +1,41 @@
+package integration_test
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestScenario16_MissingAuthorizationCode verifies the server-side
+// contribution to the spec's "Missing Authorization Code": an exchange
+// request that omits `code` (e.g. because the proxy received a callback
+// with state but no code and incorrectly tried to exchange anyway)
+// must not produce a token.
+//
+// PROXY-SIDE: detecting "the callback URL had state but no code" before
+// even attempting an exchange is the proxy's job — not the provider's.
+// See docs/integration_test_gaps.md row "scenario-16".
+//
+// Spec: P1 scenario 16.
+func TestScenario16_MissingAuthorizationCode(t *testing.T) {
+	ts := newTestServer(t)
+	c := registerClient(t, ts, "scn16", "scn16-secret", "https://app.example.com/cb")
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	// Intentionally no `code` field.
+	form.Set("redirect_uri", c.RedirectURI)
+
+	req, _ := http.NewRequest("POST", ts.URL+"/v1/oauth/tokens", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(c.Key, c.Secret)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("exchange without code must not succeed, got 200")
+	}
+}

--- a/integration/scenario_17_test.go
+++ b/integration/scenario_17_test.go
@@ -1,0 +1,158 @@
+package integration_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/testmode"
+)
+
+// TestScenario17_MalformedTokenResponses scripts a battery of malformed
+// or unusual token responses and verifies the server delivers each one
+// byte-for-byte. The server's contribution is "I can produce arbitrary
+// bytes for the proxy to choke on"; the proxy's contribution (failing
+// safely on each) lives in the AuthProxy test harness.
+//
+// Spec: P1 scenario 17.
+func TestScenario17_MalformedTokenResponses(t *testing.T) {
+	ts := newTestServer(t)
+	c := registerClient(t, ts, "scn17", "scn17-secret", "https://app.example.com/cb")
+
+	cases := []struct {
+		name        string
+		action      testmode.Action
+		wantStatus  int
+		wantBody    string            // exact string match if non-empty
+		wantHeaders map[string]string // subset match if non-empty
+	}{
+		{
+			name:       "invalid JSON",
+			action:     testmode.Action{BodyTemplate: "malformed_json"},
+			wantStatus: 200,
+			wantBody:   `{not valid json`,
+		},
+		{
+			name: "wrong content-type",
+			action: testmode.Action{
+				Status:  200,
+				Headers: map[string]string{"Content-Type": "text/plain"},
+				Body:    `{"access_token":"x","token_type":"Bearer","expires_in":3600}`,
+			},
+			wantStatus:  200,
+			wantBody:    `{"access_token":"x","token_type":"Bearer","expires_in":3600}`,
+			wantHeaders: map[string]string{"Content-Type": "text/plain"},
+		},
+		{
+			name: "missing access_token",
+			action: testmode.Action{
+				Status: 200,
+				Body:   `{"token_type":"Bearer","expires_in":3600,"scope":"read"}`,
+			},
+			wantStatus: 200,
+			wantBody:   `{"token_type":"Bearer","expires_in":3600,"scope":"read"}`,
+		},
+		{
+			name: "missing token_type",
+			action: testmode.Action{
+				Status: 200,
+				Body:   `{"access_token":"x","expires_in":3600,"scope":"read"}`,
+			},
+			wantStatus: 200,
+			wantBody:   `{"access_token":"x","expires_in":3600,"scope":"read"}`,
+		},
+		{
+			name: "unsupported token_type (MAC)",
+			action: testmode.Action{
+				Status: 200,
+				Body:   `{"access_token":"x","token_type":"MAC","expires_in":3600}`,
+			},
+			wantStatus: 200,
+			wantBody:   `{"access_token":"x","token_type":"MAC","expires_in":3600}`,
+		},
+		{
+			name: "non-integer expires_in",
+			action: testmode.Action{
+				Status: 200,
+				Body:   `{"access_token":"x","token_type":"Bearer","expires_in":"not-a-number"}`,
+			},
+			wantStatus: 200,
+			wantBody:   `{"access_token":"x","token_type":"Bearer","expires_in":"not-a-number"}`,
+		},
+		{
+			name: "negative expires_in",
+			action: testmode.Action{
+				Status: 200,
+				Body:   `{"access_token":"x","token_type":"Bearer","expires_in":-1}`,
+			},
+			wantStatus: 200,
+			wantBody:   `{"access_token":"x","token_type":"Bearer","expires_in":-1}`,
+		},
+		{
+			name: "extreme expires_in",
+			action: testmode.Action{
+				Status: 200,
+				Body:   `{"access_token":"x","token_type":"Bearer","expires_in":99999999999999}`,
+			},
+			wantStatus: 200,
+			wantBody:   `{"access_token":"x","token_type":"Bearer","expires_in":99999999999999}`,
+		},
+		{
+			name: "duplicate fields",
+			action: testmode.Action{
+				Status: 200,
+				Body:   `{"access_token":"first","access_token":"second","token_type":"Bearer","expires_in":3600}`,
+			},
+			wantStatus: 200,
+			wantBody:   `{"access_token":"first","access_token":"second","token_type":"Bearer","expires_in":3600}`,
+		},
+		{
+			name: "missing scope",
+			action: testmode.Action{
+				Status: 200,
+				Body:   `{"access_token":"x","token_type":"Bearer","expires_in":3600}`,
+			},
+			wantStatus: 200,
+			wantBody:   `{"access_token":"x","token_type":"Bearer","expires_in":3600}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts.Queue.Clear("", "")
+			enqueueScript(t, ts, "", "token", tc.action)
+
+			status, _, body := clientCredentialsGrant(t, ts, c, "read")
+			if status != tc.wantStatus {
+				t.Fatalf("status: want %d got %d body=%s", tc.wantStatus, status, body)
+			}
+			if tc.wantBody != "" && string(body) != tc.wantBody {
+				t.Fatalf("body byte-for-byte mismatch:\nwant %q\ngot  %q", tc.wantBody, body)
+			}
+			// Header subset check (we don't have access to the full
+			// response object here, but the script delivered exact
+			// headers; spot-check via a fresh request capture).
+			_ = tc.wantHeaders // covered by direct request below
+
+			if len(tc.wantHeaders) > 0 {
+				ts.Queue.Clear("", "")
+				enqueueScript(t, ts, "", "token", tc.action)
+
+				req, _ := http.NewRequest("POST", ts.URL+"/v1/oauth/tokens",
+					strings.NewReader("grant_type=client_credentials&scope=read"))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				req.SetBasicAuth(c.Key, c.Secret)
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					t.Fatalf("token req: %v", err)
+				}
+				resp.Body.Close()
+				for k, want := range tc.wantHeaders {
+					if got := resp.Header.Get(k); got != want {
+						t.Fatalf("header %s: want %q got %q", k, want, got)
+					}
+				}
+			}
+		})
+	}
+}

--- a/integration/scenario_18_test.go
+++ b/integration/scenario_18_test.go
@@ -1,0 +1,193 @@
+package integration_test
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RichardKnop/go-oauth2-server/testmode"
+)
+
+// TestScenario18_ProviderTimeout scripts a delay on each recordable
+// endpoint and uses a client with a short request timeout. The first
+// call to each endpoint times out client-side; the action is then
+// drained from the queue so a subsequent un-scripted call to the same
+// endpoint succeeds.
+//
+// Server-side, all we're proving is that delay_ms actually delays:
+// proxy retry/backoff policy is its own concern.
+//
+// Spec: P1 scenario 18.
+func TestScenario18_ProviderTimeout(t *testing.T) {
+	ts := newTestServer(t)
+	c := registerClient(t, ts, "scn18", "scn18-secret", "https://app.example.com/cb")
+	registerUser(t, ts, "scn18@example.com", "hunter22")
+
+	// Mint a token + RT once for the refresh / resource / userinfo /
+	// revoke calls. Use the un-throttled client.
+	_, baseTok, _ := passwordGrant(t, ts, c, "scn18@example.com", "hunter22", "profile")
+	if baseTok.AccessToken == "" || baseTok.RefreshToken == "" {
+		t.Fatalf("setup: expected both tokens")
+	}
+
+	const (
+		delayMs = 500
+		timeout = 75 * time.Millisecond
+	)
+	slowClient := &http.Client{Timeout: timeout}
+
+	endpoints := []struct {
+		label  string
+		script string // action goes on this script-queue endpoint label
+		fire   func(*testing.T, *http.Client) (int, error)
+		// followUp drives an un-scripted call to verify the queue drained.
+		followUp func(*testing.T) int
+	}{
+		{
+			label:  "token",
+			script: "token",
+			fire: func(t *testing.T, hc *http.Client) (int, error) {
+				return postFormBasic(hc, ts.URL+"/v1/oauth/tokens", c.Key, c.Secret,
+					url.Values{"grant_type": []string{"client_credentials"}, "scope": []string{"read"}})
+			},
+			followUp: func(t *testing.T) int {
+				st, _, _ := clientCredentialsGrant(t, ts, c, "read")
+				return st
+			},
+		},
+		{
+			label:  "refresh",
+			script: "refresh",
+			fire: func(t *testing.T, hc *http.Client) (int, error) {
+				return postFormBasic(hc, ts.URL+"/v1/oauth/tokens", c.Key, c.Secret,
+					url.Values{"grant_type": []string{"refresh_token"}, "refresh_token": []string{baseTok.RefreshToken}})
+			},
+			followUp: func(t *testing.T) int {
+				// Use a fresh RT for the un-scripted follow-up — refresh
+				// is destructive due to rotation.
+				_, freshTok, _ := passwordGrant(t, ts, c, "scn18@example.com", "hunter22", "profile")
+				st, _, _ := refresh(t, ts, c, freshTok.RefreshToken)
+				return st
+			},
+		},
+		{
+			label:  "revoke",
+			script: "revoke",
+			fire: func(t *testing.T, hc *http.Client) (int, error) {
+				return postFormBasic(hc, ts.URL+"/v1/oauth/revoke", c.Key, c.Secret,
+					url.Values{"token": []string{"some-token"}})
+			},
+			followUp: func(t *testing.T) int {
+				return revokeToken(t, ts, c, "some-other-token", "")
+			},
+		},
+		{
+			label:  "userinfo",
+			script: "userinfo",
+			fire: func(t *testing.T, hc *http.Client) (int, error) {
+				req, _ := http.NewRequest("GET", ts.URL+"/v1/oauth/userinfo", nil)
+				req.Header.Set("Authorization", "Bearer "+baseTok.AccessToken)
+				resp, err := hc.Do(req)
+				if err != nil {
+					return 0, err
+				}
+				resp.Body.Close()
+				return resp.StatusCode, nil
+			},
+			followUp: func(t *testing.T) int {
+				st, _, _ := userinfo(t, ts, baseTok.AccessToken)
+				return st
+			},
+		},
+		{
+			label:  "resource",
+			script: "resource",
+			fire: func(t *testing.T, hc *http.Client) (int, error) {
+				req, _ := http.NewRequest("GET", ts.URL+"/test/resource/foo", nil)
+				req.Header.Set("Authorization", "Bearer "+baseTok.AccessToken)
+				resp, err := hc.Do(req)
+				if err != nil {
+					return 0, err
+				}
+				resp.Body.Close()
+				return resp.StatusCode, nil
+			},
+			followUp: func(t *testing.T) int {
+				st, _, _ := callResource(t, ts, baseTok.AccessToken, "/test/resource/foo")
+				return st
+			},
+		},
+	}
+
+	for _, tc := range endpoints {
+		t.Run(tc.label+" times out", func(t *testing.T) {
+			ts.Queue.Clear("", "")
+			enqueueScript(t, ts, "", tc.script, testmode.Action{
+				DelayMS: delayMs,
+				Status:  200,
+				Body:    `{"never":"delivered"}`,
+			})
+
+			start := time.Now()
+			_, err := tc.fire(t, slowClient)
+			elapsed := time.Since(start)
+			if err == nil {
+				t.Fatalf("%s: expected timeout error, got nil", tc.label)
+			}
+			if !isTimeoutErr(err) {
+				t.Fatalf("%s: expected timeout error, got %v", tc.label, err)
+			}
+			// Sanity: the timeout fired close to the configured client
+			// timeout, not the full server delay.
+			if elapsed > timeout*4 {
+				t.Fatalf("%s: client took too long (%v) — expected ~%v", tc.label, elapsed, timeout)
+			}
+		})
+
+		t.Run(tc.label+" un-scripted call after timeout succeeds", func(t *testing.T) {
+			// The script middleware popped its action on the timed-out
+			// request, so the queue is already empty by the time we get
+			// here. The previous handler goroutine is still sleeping
+			// in the background; it will write to the closed connection
+			// and return harmlessly. We don't need to wait for it.
+			st := tc.followUp(t)
+			// Most endpoints return 200 on the un-scripted path. revoke
+			// is silent-200 even on unknown tokens. Token / refresh /
+			// userinfo / resource all return 200 here.
+			if st != http.StatusOK {
+				t.Fatalf("%s: un-scripted follow-up expected 200, got %d", tc.label, st)
+			}
+		})
+	}
+}
+
+// postFormBasic posts a form with HTTP Basic auth and returns the
+// status code (or the error if the request never completes).
+func postFormBasic(hc *http.Client, u, user, pass string, form url.Values) (int, error) {
+	req, _ := http.NewRequest("POST", u, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(user, pass)
+	resp, err := hc.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	resp.Body.Close()
+	return resp.StatusCode, nil
+}
+
+// isTimeoutErr returns true if err looks like an http.Client timeout.
+// We match on the message because the underlying cause in net/http is
+// either a *url.Error wrapping a timeout, a context.DeadlineExceeded,
+// or a net.Error with Timeout()==true; the message is reliably present
+// in all three.
+func isTimeoutErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Client.Timeout") ||
+		strings.Contains(msg, "context deadline exceeded") ||
+		strings.Contains(msg, "i/o timeout")
+}


### PR DESCRIPTION
Closes #31. Tracking: #26.

Six P1 scenarios covering optional-refresh, PKCE, callback edge cases, malformed responses, and timeouts.

## Scenarios

### `TestScenario13_NoRefreshToken` (P1 #13)

Script a token response that omits `refresh_token`. Server delivers it byte-for-byte, recorder captures the inbound request. The proxy's "we got no RT, so degrade gracefully" path is its own concern.

### `TestScenario14_PKCEValidation` (P1 #14) — 6 subtests

| case | expected |
| --- | --- |
| S256 happy path | 200 |
| S256 mismatch | 400, body mentions `code_verifier` |
| stored challenge, missing verifier | 400 |
| `plain` method | 200 |
| `none` client without challenge at authorize | 400 |
| unknown method `S512` at authorize | 400 |

### `TestScenario15_CallbackBothCodeAndError` (P1 #15)

Server-side demonstration that `/test/authorize` produces both the `code+state` shape (approve) and the `error=access_denied+state` shape (deny). Proxy-side handling of a malicious URL containing both is punted to `docs/integration_test_gaps.md` row `scenario-15`.

### `TestScenario16_MissingAuthorizationCode` (P1 #16)

Exchange request without a `code` field is rejected. Proxy-side detection of "callback had state but no code" is punted to gaps doc row `scenario-16`.

### `TestScenario17_MalformedTokenResponses` (P1 #17) — 10 subtests

Table-driven battery: invalid JSON, wrong content-type (header asserted), missing `access_token`, missing `token_type`, `MAC` token type, non-integer / negative / extreme `expires_in`, duplicate fields, missing `scope`. Each scripted action is delivered byte-for-byte. The proxy choking on each is the proxy's job.

### `TestScenario18_ProviderTimeout` (P1 #18)

`delay_ms=500` scripted on each recordable endpoint (`token`, `refresh`, `revoke`, `userinfo`, `resource`). Client uses a 75ms timeout and observes the timeout error within ~4× the timeout (i.e. not the full server delay). Un-scripted follow-up call succeeds because the action was already popped on the timed-out request. Server-side handler goroutine continues sleeping; writes to a closed connection harmlessly.

## Test plan

- [x] `go build ./... && go vet ./... && gofmt -l .` clean
- [x] `go test ./integration/...` — 19 scenarios + binary smoke green, ~9s total
- [x] All Phase 1–4 scenarios still pass