### PR TITLE
Phase 6: P1 resource & proxied API responses

### DIFF
--- a/integration/scenario_20_test.go
+++ b/integration/scenario_20_test.go
@@ -1,0 +1,63 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/testmode"
+)
+
+// TestScenario20_ProxyAPICallWithValidToken covers the spec's "Proxy
+// API Call With Valid Token": real OAuth flow → access token → hit
+// /test/resource/<path> with Authorization: Bearer <token>. The
+// default body carries sub/client_id/scope/path and the recorder
+// captures the request with the bearer redacted.
+//
+// Spec: P1 scenario 20.
+func TestScenario20_ProxyAPICallWithValidToken(t *testing.T) {
+	ts := newTestServer(t)
+	c := registerClient(t, ts, "scn20", "scn20-secret", "https://app.example.com/cb")
+	registerUser(t, ts, "scn20@example.com", "hunter22")
+
+	_, tok, _ := passwordGrant(t, ts, c, "scn20@example.com", "hunter22", "read")
+	if tok.AccessToken == "" {
+		t.Fatalf("setup: missing access token")
+	}
+
+	const path = "/test/resource/some/sub/path"
+	status, _, body := callResource(t, ts, tok.AccessToken, path)
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", status, body)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatalf("decode body: %v body=%s", err, body)
+	}
+	if doc["path"] != path {
+		t.Fatalf("expected path=%s, got %v", path, doc["path"])
+	}
+	if doc["scope"] != "read" {
+		t.Fatalf("expected scope=read, got %v", doc["scope"])
+	}
+	if doc["client_id"] == nil || doc["client_id"] == "" {
+		t.Fatalf("expected client_id in body, got %v", doc["client_id"])
+	}
+	if doc["sub"] == nil || doc["sub"] == "" {
+		t.Fatalf("expected sub in body, got %v", doc["sub"])
+	}
+
+	// Recorder captures the request with bearer redacted.
+	entries := ts.Recorder.Snapshot(testmode.SnapshotFilter{Endpoint: "resource"})
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 recorded resource entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.Path != path {
+		t.Fatalf("expected recorded path=%s, got %q", path, e.Path)
+	}
+	if got := e.Headers["Authorization"]; got != "Bearer <redacted>" {
+		t.Fatalf("expected Bearer <redacted>, got %q", got)
+	}
+}

--- a/integration/scenario_21_test.go
+++ b/integration/scenario_21_test.go
@@ -1,0 +1,106 @@
+package integration_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/testmode"
+)
+
+// TestScenario21_ProxyAPI401 covers the spec's "Proxy API Call
+// Receives 401" — both natural causes (expired, revoked, malformed,
+// tampered) and a scripted 401 from the resource endpoint.
+//
+// Spec: P1 scenario 21.
+func TestScenario21_ProxyAPI401(t *testing.T) {
+	ts := newTestServer(t)
+	c := registerClient(t, ts, "scn21", "scn21-secret", "https://app.example.com/cb")
+	registerUser(t, ts, "scn21@example.com", "hunter22")
+
+	mintToken := func(t *testing.T) string {
+		t.Helper()
+		_, tok, _ := passwordGrant(t, ts, c, "scn21@example.com", "hunter22", "read")
+		if tok.AccessToken == "" {
+			t.Fatalf("setup: missing access token")
+		}
+		return tok.AccessToken
+	}
+
+	t.Run("expired token", func(t *testing.T) {
+		ts.Queue.Clear("", "")
+		at := mintToken(t)
+		expireAccessToken(t, ts, at)
+		status, hdr, _ := callResource(t, ts, at, "/test/resource/foo")
+		if status != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", status)
+		}
+		if !strings.Contains(hdr.Get("WWW-Authenticate"), `error="invalid_token"`) {
+			t.Fatalf("expected invalid_token in WWW-Authenticate, got %q", hdr.Get("WWW-Authenticate"))
+		}
+	})
+
+	t.Run("revoked token", func(t *testing.T) {
+		ts.Queue.Clear("", "")
+		at := mintToken(t)
+		adminRevoke(t, ts, map[string]string{"token": at})
+		status, hdr, _ := callResource(t, ts, at, "/test/resource/foo")
+		if status != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", status)
+		}
+		if !strings.Contains(hdr.Get("WWW-Authenticate"), `error="invalid_token"`) {
+			t.Fatalf("expected invalid_token, got %q", hdr.Get("WWW-Authenticate"))
+		}
+	})
+
+	t.Run("malformed token (wrong format)", func(t *testing.T) {
+		ts.Queue.Clear("", "")
+		status, hdr, _ := callResource(t, ts, "not-a-real-token-format", "/test/resource/foo")
+		if status != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", status)
+		}
+		if !strings.Contains(hdr.Get("WWW-Authenticate"), `error="invalid_token"`) {
+			t.Fatalf("expected invalid_token, got %q", hdr.Get("WWW-Authenticate"))
+		}
+	})
+
+	t.Run("tampered token (one char changed)", func(t *testing.T) {
+		ts.Queue.Clear("", "")
+		at := mintToken(t)
+		// Flip one character in the middle of the UUID.
+		i := len(at) / 2
+		var b byte
+		if at[i] == 'a' {
+			b = 'b'
+		} else {
+			b = 'a'
+		}
+		tampered := at[:i] + string(b) + at[i+1:]
+		status, _, _ := callResource(t, ts, tampered, "/test/resource/foo")
+		if status != http.StatusUnauthorized {
+			t.Fatalf("expected 401 for tampered token, got %d", status)
+		}
+	})
+
+	t.Run("scripted 401 with custom body", func(t *testing.T) {
+		ts.Queue.Clear("", "")
+		at := mintToken(t)
+		const body = `{"error":"invalid_token","error_description":"upstream says no"}`
+		enqueueScript(t, ts, "", "resource", testmode.Action{
+			Status:  http.StatusUnauthorized,
+			Headers: map[string]string{"WWW-Authenticate": `Bearer error="invalid_token"`},
+			Body:    body,
+		})
+
+		status, hdr, gotBody := callResource(t, ts, at, "/test/resource/foo")
+		if status != http.StatusUnauthorized {
+			t.Fatalf("expected scripted 401, got %d", status)
+		}
+		if string(gotBody) != body {
+			t.Fatalf("body byte-for-byte mismatch:\nwant %q\ngot  %q", body, gotBody)
+		}
+		if got := hdr.Get("WWW-Authenticate"); !strings.Contains(got, `error="invalid_token"`) {
+			t.Fatalf("expected scripted WWW-Authenticate, got %q", got)
+		}
+	})
+}

--- a/integration/scenario_22_test.go
+++ b/integration/scenario_22_test.go
@@ -1,0 +1,87 @@
+package integration_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestScenario22_ProxyAPI403 covers the spec's "Proxy API Call
+// Receives 403": scope-policy mismatch returns 403 with a
+// WWW-Authenticate header that reports the required scope, so the
+// proxy can surface a meaningful "missing permission" error.
+//
+// The spec's example uses `admin` as the required scope, but the test
+// provider only seeds `read`, `read_write`, `profile`, and `email`. To
+// avoid mutating the seed for one scenario, we use `read_write` as
+// the required scope and issue the user a `read`-only token. The
+// shape of the assertion is identical.
+//
+// Spec: P1 scenario 22.
+func TestScenario22_ProxyAPI403(t *testing.T) {
+	ts := newTestServer(t)
+	c := registerClient(t, ts, "scn22", "scn22-secret", "https://app.example.com/cb")
+	registerUser(t, ts, "scn22@example.com", "hunter22")
+
+	const adminPath = "/test/resource/admin"
+
+	// Register the policy: hitting adminPath requires `read_write`.
+	policyBody, _ := json.Marshal(map[string]string{
+		"path":           adminPath,
+		"required_scope": "read_write",
+	})
+	resp, err := http.Post(ts.URL+"/test/resource-policy", "application/json", bytes.NewReader(policyBody))
+	if err != nil {
+		t.Fatalf("policy: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("policy register expected 204, got %d", resp.StatusCode)
+	}
+
+	t.Run("read-only token at admin path returns 403", func(t *testing.T) {
+		_, tok, _ := passwordGrant(t, ts, c, "scn22@example.com", "hunter22", "read")
+		if tok.AccessToken == "" {
+			t.Fatalf("setup: missing access token")
+		}
+
+		status, hdr, body := callResource(t, ts, tok.AccessToken, adminPath)
+		if status != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d body=%s", status, body)
+		}
+		got := hdr.Get("WWW-Authenticate")
+		if !strings.Contains(got, `error="insufficient_scope"`) {
+			t.Fatalf("expected insufficient_scope, got %q", got)
+		}
+		if !strings.Contains(got, `scope="read_write"`) {
+			t.Fatalf("expected scope=\"read_write\" in WWW-Authenticate, got %q", got)
+		}
+	})
+
+	t.Run("token with required scope passes the policy", func(t *testing.T) {
+		_, tok, _ := passwordGrant(t, ts, c, "scn22@example.com", "hunter22", "read_write")
+		if tok.AccessToken == "" {
+			t.Fatalf("setup: missing access token")
+		}
+
+		status, _, body := callResource(t, ts, tok.AccessToken, adminPath)
+		if status != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", status, body)
+		}
+	})
+
+	t.Run("non-admin path is unaffected by the admin policy", func(t *testing.T) {
+		_, tok, _ := passwordGrant(t, ts, c, "scn22@example.com", "hunter22", "read")
+		if tok.AccessToken == "" {
+			t.Fatalf("setup: missing access token")
+		}
+
+		// /test/resource/foo has no policy; read-only token works.
+		status, _, body := callResource(t, ts, tok.AccessToken, "/test/resource/foo")
+		if status != http.StatusOK {
+			t.Fatalf("expected 200 for un-policed path, got %d body=%s", status, body)
+		}
+	})
+}

--- a/integration/scenario_23_test.go
+++ b/integration/scenario_23_test.go
@@ -1,0 +1,48 @@
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/testmode"
+)
+
+// TestScenario23_ProxyAPI429 covers the spec's "Proxy API Call
+// Receives 429": script a 429 with a Retry-After header on the
+// resource endpoint, verify the proxy receives both, and confirm the
+// queue empties so subsequent un-scripted calls succeed.
+//
+// Spec: P1 scenario 23.
+func TestScenario23_ProxyAPI429(t *testing.T) {
+	ts := newTestServer(t)
+	c := registerClient(t, ts, "scn23", "scn23-secret", "https://app.example.com/cb")
+	registerUser(t, ts, "scn23@example.com", "hunter22")
+
+	_, tok, _ := passwordGrant(t, ts, c, "scn23@example.com", "hunter22", "read")
+	if tok.AccessToken == "" {
+		t.Fatalf("setup: missing access token")
+	}
+
+	enqueueScript(t, ts, "", "resource", testmode.Action{
+		Status:  http.StatusTooManyRequests,
+		Headers: map[string]string{"Retry-After": "30"},
+		Body:    `{"error":"rate_limited"}`,
+	})
+
+	status, hdr, body := callResource(t, ts, tok.AccessToken, "/test/resource/foo")
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d body=%s", status, body)
+	}
+	if got := hdr.Get("Retry-After"); got != "30" {
+		t.Fatalf("expected Retry-After=30, got %q", got)
+	}
+	if string(body) != `{"error":"rate_limited"}` {
+		t.Fatalf("body byte-for-byte mismatch, got %q", body)
+	}
+
+	// Following call (queue empty) succeeds — confirms 429 was a one-shot.
+	st2, _, body2 := callResource(t, ts, tok.AccessToken, "/test/resource/foo")
+	if st2 != http.StatusOK {
+		t.Fatalf("follow-up after 429 expected 200, got %d body=%s", st2, body2)
+	}
+}

--- a/integration/scenario_24_test.go
+++ b/integration/scenario_24_test.go
@@ -1,0 +1,51 @@
+package integration_test
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/testmode"
+)
+
+// TestScenario24_ProxyAPI5xx covers the spec's "Proxy API Call
+// Receives 5xx" — for each of 500, 502, 503, 504 verify the scripted
+// status reaches the client byte-for-byte and a follow-up un-scripted
+// call returns 200.
+//
+// Spec: P1 scenario 24.
+func TestScenario24_ProxyAPI5xx(t *testing.T) {
+	ts := newTestServer(t)
+	c := registerClient(t, ts, "scn24", "scn24-secret", "https://app.example.com/cb")
+	registerUser(t, ts, "scn24@example.com", "hunter22")
+
+	_, tok, _ := passwordGrant(t, ts, c, "scn24@example.com", "hunter22", "read")
+	if tok.AccessToken == "" {
+		t.Fatalf("setup: missing access token")
+	}
+
+	for _, code := range []int{500, 502, 503, 504} {
+		t.Run(strconv.Itoa(code), func(t *testing.T) {
+			ts.Queue.Clear("", "")
+			body := `{"error":"upstream_` + strconv.Itoa(code) + `"}`
+			enqueueScript(t, ts, "", "resource", testmode.Action{
+				Status: code,
+				Body:   body,
+			})
+
+			status, _, gotBody := callResource(t, ts, tok.AccessToken, "/test/resource/foo")
+			if status != code {
+				t.Fatalf("expected scripted %d, got %d", code, status)
+			}
+			if string(gotBody) != body {
+				t.Fatalf("body byte-for-byte mismatch:\nwant %q\ngot  %q", body, gotBody)
+			}
+
+			// Un-scripted follow-up returns 200 (queue empty).
+			st2, _, body2 := callResource(t, ts, tok.AccessToken, "/test/resource/foo")
+			if st2 != http.StatusOK {
+				t.Fatalf("follow-up after %d expected 200, got %d body=%s", code, st2, body2)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #32. Tracking: #26.

Five spec-mapped scenarios covering resource-server behavior and proxied API response codes.

## Scenarios

### `TestScenario20_ProxyAPICallWithValidToken` (P1 #20)

Real OAuth flow → access token → hit `/test/resource/some/sub/path` with `Authorization: Bearer <token>`. Default body carries `sub` / `client_id` / `scope` / `path`; recorder captures the request with `Bearer <redacted>`.

### `TestScenario21_ProxyAPI401` (P1 #21) — 5 subtests

| variant | source |
| --- | --- |
| expired token | DB back-dated `expires_at` |
| revoked token | `/test/revoke` admin path |
| malformed token (wrong format) | bogus token string |
| tampered token (one char changed) | flip one byte in a real token |
| scripted 401 with custom body | `/test/scripts {endpoint:"resource", status:401, ...}` |

The first four are server-issued 401s with `WWW-Authenticate: Bearer error="invalid_token"`; the fifth proves arbitrary 401s can be injected byte-for-byte.

### `TestScenario22_ProxyAPI403` (P1 #22) — 3 subtests

Register a scope policy on `/test/resource/admin` requiring `read_write`. Read-only token returns 403 with `WWW-Authenticate: Bearer ..., error="insufficient_scope", scope="read_write"`. Read_write token passes. Un-policed paths unaffected.

The spec uses `admin` as the required scope, but the seed only has `read`/`read_write`/`profile`/`email`. Using `read_write` keeps the assertion shape identical without mutating the seed.

### `TestScenario23_ProxyAPI429` (P1 #23)

Scripted 429 with `Retry-After: 30` → client receives both byte-for-byte. Un-scripted follow-up returns 200 (action was one-shot).

### `TestScenario24_ProxyAPI5xx` (P1 #24) — 4 subtests

For each of 500, 502, 503, 504: scripted status reaches the client byte-for-byte alongside the exact body; un-scripted follow-up returns 200 each time.

## Test plan

- [x] `go build ./... && go vet ./... && gofmt -l .` clean
- [x] `go test ./integration/...` — 24 scenarios + binary smoke green, ~10s total
- [x] All Phase 1–5 scenarios still pass