### PR TITLE
Phase 7: P2 advanced — scenarios 25-30

### DIFF
--- a/integration/scenario_25_test.go
+++ b/integration/scenario_25_test.go
@@ -1,0 +1,74 @@
+package integration_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestScenario25_IncrementalAuthorization covers the spec's
+// "Incremental Authorization": after a successful flow with a narrow
+// scope, the same user re-authorizes the same client with a broader
+// scope. The new access token has the broader scope and the original
+// access token continues to work until expiry — failed upgrade does
+// not destroy existing credentials.
+//
+// Server quirk worth noting: GetOrCreateRefreshToken finds an existing
+// non-revoked RT for (client, user) and returns it as-is. So a second
+// authorization for the same (client, user) pair reuses the prior RT
+// rather than minting one with the broader scope. The access tokens
+// are independent (one per Login call) so the broader-scope assertion
+// holds at the access-token layer; we don't assert anything specific
+// about the second-flow refresh token's scope.
+//
+// Spec: P2 scenario 25.
+func TestScenario25_IncrementalAuthorization(t *testing.T) {
+	ts := newTestServer(t)
+	c := registerClient(t, ts, "scn25", "scn25-secret", "https://app.example.com/cb")
+	u := registerUser(t, ts, "scn25@example.com", "hunter22")
+
+	// First flow: scope=read.
+	redirect1 := authorize(t, ts, "approve", authorizeParams{
+		Client: c, User: u, Scope: "read",
+	})
+	code1 := extractCode(t, redirect1)
+	status1, tok1, body1 := exchangeCode(t, ts, c, code1)
+	if status1 != http.StatusOK {
+		t.Fatalf("first exchange expected 200, got %d body=%s", status1, body1)
+	}
+	if tok1.Scope != "read" {
+		t.Fatalf("first token expected scope=read, got %q", tok1.Scope)
+	}
+
+	// Second flow: re-authorize with the broader scope.
+	redirect2 := authorize(t, ts, "approve", authorizeParams{
+		Client: c, User: u, Scope: "read_write",
+	})
+	code2 := extractCode(t, redirect2)
+	status2, tok2, body2 := exchangeCode(t, ts, c, code2)
+	if status2 != http.StatusOK {
+		t.Fatalf("second exchange expected 200, got %d body=%s", status2, body2)
+	}
+	if tok2.Scope != "read_write" {
+		t.Fatalf("second token expected scope=read_write, got %q", tok2.Scope)
+	}
+	if tok2.AccessToken == tok1.AccessToken {
+		t.Fatalf("second flow should issue a new access token, got same as first")
+	}
+
+	// Original access token still works at the resource (existing
+	// credentials are not destroyed by the upgrade).
+	st1, _, b1 := callResource(t, ts, tok1.AccessToken, "/test/resource/foo")
+	if st1 != http.StatusOK {
+		t.Fatalf("original access token should still work, got %d body=%s", st1, b1)
+	}
+
+	// New access token has the broader scope visible in the default body.
+	st2, _, b2 := callResource(t, ts, tok2.AccessToken, "/test/resource/foo")
+	if st2 != http.StatusOK {
+		t.Fatalf("new access token should work, got %d body=%s", st2, b2)
+	}
+	if !strings.Contains(string(b2), `"scope":"read_write"`) {
+		t.Fatalf("new resource body should report scope=read_write, got %s", b2)
+	}
+}

--- a/integration/scenario_26_test.go
+++ b/integration/scenario_26_test.go
@@ -1,0 +1,70 @@
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestScenario26_ProxyInitiatedDisconnect covers the spec's
+// "Proxy-Initiated Disconnect" via the RFC 7009 revocation endpoint:
+//
+//   - revoking the refresh token cascades to the access token
+//   - the endpoint silently returns 200 for unknown / wrong-client
+//     tokens, but does not actually revoke them
+//
+// Spec: P2 scenario 26.
+func TestScenario26_ProxyInitiatedDisconnect(t *testing.T) {
+	ts := newTestServer(t)
+	c := registerClient(t, ts, "scn26", "scn26-secret", "https://app.example.com/cb")
+	other := registerClient(t, ts, "scn26-other", "other-secret", "https://app.example.com/cb")
+	registerUser(t, ts, "scn26@example.com", "hunter22")
+
+	t.Run("revoking RT via /v1/oauth/revoke disconnects the connection", func(t *testing.T) {
+		_, tok, _ := passwordGrant(t, ts, c, "scn26@example.com", "hunter22", "read")
+		if tok.AccessToken == "" || tok.RefreshToken == "" {
+			t.Fatalf("setup: missing tokens")
+		}
+
+		if status := revokeToken(t, ts, c, tok.RefreshToken, "refresh_token"); status != http.StatusOK {
+			t.Fatalf("revoke expected 200, got %d", status)
+		}
+
+		// Refresh fails.
+		st, _, _ := refresh(t, ts, c, tok.RefreshToken)
+		if st != http.StatusBadRequest {
+			t.Fatalf("post-revoke refresh expected 400, got %d", st)
+		}
+
+		// Cascaded access token at resource is 401.
+		st2, _, _ := callResource(t, ts, tok.AccessToken, "/test/resource/foo")
+		if st2 != http.StatusUnauthorized {
+			t.Fatalf("post-revoke resource expected 401, got %d", st2)
+		}
+	})
+
+	t.Run("revoking unknown token returns 200 silently per RFC 7009", func(t *testing.T) {
+		if status := revokeToken(t, ts, c, "00000000-0000-0000-0000-000000000000", ""); status != http.StatusOK {
+			t.Fatalf("unknown-token revoke expected 200, got %d", status)
+		}
+	})
+
+	t.Run("cross-client revoke returns 200 but does not actually revoke", func(t *testing.T) {
+		// Issue a token belonging to `other`.
+		_, otherTok, _ := passwordGrant(t, ts, other, "scn26@example.com", "hunter22", "read")
+		if otherTok.AccessToken == "" {
+			t.Fatalf("setup: missing other-client token")
+		}
+
+		// `c` (a different client) tries to revoke `other`'s access token.
+		if status := revokeToken(t, ts, c, otherTok.AccessToken, "access_token"); status != http.StatusOK {
+			t.Fatalf("cross-client revoke expected silent 200 per RFC 7009, got %d", status)
+		}
+
+		// `other`'s token still works at the resource — the cross-client
+		// revoke was silently ignored.
+		st, _, _ := callResource(t, ts, otherTok.AccessToken, "/test/resource/foo")
+		if st != http.StatusOK {
+			t.Fatalf("token should still be valid for owning client, got %d", st)
+		}
+	})
+}

--- a/integration/scenario_27_test.go
+++ b/integration/scenario_27_test.go
@@ -1,0 +1,71 @@
+package integration_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// TestScenario27_ProviderIdentityChanges covers the spec's "Provider
+// Account Identity Changes": the provider can swap the `sub` returned
+// by /v1/oauth/userinfo without re-issuing tokens, so a proxy can
+// detect identity drift mid-session.
+//
+// Spec: P2 scenario 27.
+func TestScenario27_ProviderIdentityChanges(t *testing.T) {
+	ts := newTestServer(t)
+	c := registerClient(t, ts, "scn27", "scn27-secret", "https://app.example.com/cb")
+	u := registerUser(t, ts, "scn27@example.com", "hunter22",
+		userOpts{Email: "scn27@example.com", DisplayName: "Scenario 27"})
+
+	_, tok, _ := passwordGrant(t, ts, c, "scn27@example.com", "hunter22", "profile")
+	if tok.AccessToken == "" {
+		t.Fatalf("setup: missing access token")
+	}
+
+	t.Run("initial userinfo returns user UUID as sub", func(t *testing.T) {
+		status, _, body := userinfo(t, ts, tok.AccessToken)
+		if status != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", status, body)
+		}
+		var ui struct{ Sub string }
+		json.Unmarshal(body, &ui)
+		if ui.Sub != u.ID {
+			t.Fatalf("expected sub=%q, got %q", u.ID, ui.Sub)
+		}
+	})
+
+	t.Run("swap-subject changes sub on the same access token", func(t *testing.T) {
+		swap, _ := json.Marshal(map[string]string{"new_sub": "iss://example/users/42"})
+		resp, _ := http.Post(ts.URL+"/test/users/"+u.ID+"/swap-subject", "application/json", bytes.NewReader(swap))
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("swap-subject expected 200, got %d", resp.StatusCode)
+		}
+
+		// Same access token; userinfo now reports the override.
+		_, _, body := userinfo(t, ts, tok.AccessToken)
+		var ui struct{ Sub string }
+		json.Unmarshal(body, &ui)
+		if ui.Sub != "iss://example/users/42" {
+			t.Fatalf("expected swapped sub, got %q (body=%s)", ui.Sub, body)
+		}
+	})
+
+	t.Run("clearing override falls back to UUID", func(t *testing.T) {
+		clear, _ := json.Marshal(map[string]string{"new_sub": ""})
+		resp, _ := http.Post(ts.URL+"/test/users/"+u.ID+"/swap-subject", "application/json", bytes.NewReader(clear))
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("clear expected 200, got %d", resp.StatusCode)
+		}
+
+		_, _, body := userinfo(t, ts, tok.AccessToken)
+		var ui struct{ Sub string }
+		json.Unmarshal(body, &ui)
+		if ui.Sub != u.ID {
+			t.Fatalf("expected sub to fall back to UUID, got %q (body=%s)", ui.Sub, body)
+		}
+	})
+}

--- a/integration/scenario_28_test.go
+++ b/integration/scenario_28_test.go
@@ -1,0 +1,83 @@
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestScenario28_MultipleConnections covers the spec's "Multiple
+// Connections to Same Provider":
+//
+//   - Same tenant can hold multiple independent client registrations
+//   - Token storage / revocation are isolated per (client, user) pair
+//   - Revoking one chain doesn't touch the other
+//
+// Spec: P2 scenario 28.
+func TestScenario28_MultipleConnections(t *testing.T) {
+	ts := newTestServer(t)
+
+	cA := registerClient(t, ts, "scn28-a", "secret-a", "https://app.example.com/cb")
+	cB := registerClient(t, ts, "scn28-b", "secret-b", "https://app.example.com/cb")
+	registerUser(t, ts, "scn28@example.com", "hunter22")
+
+	t.Run("same user authorizing two clients yields independent chains", func(t *testing.T) {
+		_, tokA, _ := passwordGrant(t, ts, cA, "scn28@example.com", "hunter22", "read")
+		_, tokB, _ := passwordGrant(t, ts, cB, "scn28@example.com", "hunter22", "read")
+		if tokA.AccessToken == "" || tokB.AccessToken == "" {
+			t.Fatalf("setup: expected both tokens")
+		}
+		if tokA.AccessToken == tokB.AccessToken {
+			t.Fatalf("each client should get a distinct access token")
+		}
+		if tokA.RefreshToken == tokB.RefreshToken {
+			t.Fatalf("each client should get a distinct refresh token")
+		}
+
+		// Both tokens work at the resource.
+		if st, _, _ := callResource(t, ts, tokA.AccessToken, "/test/resource/foo"); st != http.StatusOK {
+			t.Fatalf("tokenA at resource expected 200, got %d", st)
+		}
+		if st, _, _ := callResource(t, ts, tokB.AccessToken, "/test/resource/foo"); st != http.StatusOK {
+			t.Fatalf("tokenB at resource expected 200, got %d", st)
+		}
+
+		// Revoke chain A via the admin endpoint.
+		adminRevoke(t, ts, map[string]string{"token": tokA.RefreshToken})
+
+		// chain A's access token is now invalid (cascade) ...
+		if st, _, _ := callResource(t, ts, tokA.AccessToken, "/test/resource/foo"); st != http.StatusUnauthorized {
+			t.Fatalf("chain A access token should be revoked, got %d", st)
+		}
+		// ... but chain B is untouched.
+		if st, _, _ := callResource(t, ts, tokB.AccessToken, "/test/resource/foo"); st != http.StatusOK {
+			t.Fatalf("chain B should be unaffected by chain A revoke, got %d", st)
+		}
+		// And chain B's refresh still works.
+		stRefresh, refreshedB, _ := refresh(t, ts, cB, tokB.RefreshToken)
+		if stRefresh != http.StatusOK {
+			t.Fatalf("chain B refresh should still work, got %d", stRefresh)
+		}
+		if refreshedB.AccessToken == "" {
+			t.Fatalf("chain B refresh should produce a new access token")
+		}
+	})
+
+	t.Run("clientA cannot revoke clientB's tokens", func(t *testing.T) {
+		// Fresh token for clientB.
+		_, tokB, _ := passwordGrant(t, ts, cB, "scn28@example.com", "hunter22", "read")
+		if tokB.AccessToken == "" {
+			t.Fatalf("setup: missing tokenB")
+		}
+
+		// clientA's credentials, attempting to revoke clientB's access token.
+		// RFC 7009: silent 200, no actual revocation.
+		if status := revokeToken(t, ts, cA, tokB.AccessToken, "access_token"); status != http.StatusOK {
+			t.Fatalf("cross-client revoke expected silent 200, got %d", status)
+		}
+
+		// clientB's token still works.
+		if st, _, _ := callResource(t, ts, tokB.AccessToken, "/test/resource/foo"); st != http.StatusOK {
+			t.Fatalf("tokenB should still be valid for clientB, got %d", st)
+		}
+	})
+}

--- a/integration/scenario_29_test.go
+++ b/integration/scenario_29_test.go
@@ -1,0 +1,77 @@
+package integration_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+// TestScenario29_OpenRedirectProtection covers the server-side parts
+// of the spec's "Open Redirect Protection": redirect_uri at /test/
+// authorize must match the client's registered URI, and a missing
+// redirect_uri falls back to the registered URI.
+//
+// PROXY-SIDE: validating the post-auth return URL the proxy itself
+// redirects users to is not in the test provider's purview. See
+// docs/integration_test_gaps.md row "scenario-29".
+//
+// Spec: P2 scenario 29.
+func TestScenario29_OpenRedirectProtection(t *testing.T) {
+	ts := newTestServer(t)
+	const registered = "https://app.example.com/cb"
+	c := registerClient(t, ts, "scn29", "scn29-secret", registered)
+	u := registerUser(t, ts, "scn29@example.com", "hunter22")
+
+	t.Run("redirect_uri mismatch is rejected", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"client_id":    c.Key,
+			"user_id":      u.ID,
+			"redirect_uri": "https://attacker.example.com/cb",
+			"scope":        "read",
+			"decision":     "approve",
+		})
+		resp, err := http.Post(ts.URL+"/test/authorize", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("authorize: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected 400 for redirect_uri mismatch, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("missing redirect_uri falls back to registered URI", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"client_id": c.Key,
+			"user_id":   u.ID,
+			"scope":     "read",
+			"decision":  "approve",
+			// redirect_uri intentionally absent
+		})
+		resp, err := http.Post(ts.URL+"/test/authorize", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("authorize: %v", err)
+		}
+		raw, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 with fallback redirect_uri, got %d body=%s", resp.StatusCode, raw)
+		}
+		var r struct {
+			RedirectURL string `json:"redirect_url"`
+		}
+		if err := json.Unmarshal(raw, &r); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		parsed, err := url.Parse(r.RedirectURL)
+		if err != nil {
+			t.Fatalf("parse redirect: %v", err)
+		}
+		if got := parsed.Scheme + "://" + parsed.Host + parsed.Path; got != registered {
+			t.Fatalf("expected fallback to registered URI %q, got %q", registered, got)
+		}
+	})
+}

--- a/integration/scenario_30_test.go
+++ b/integration/scenario_30_test.go
@@ -1,0 +1,59 @@
+package integration_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestScenario30_ClockSkew covers the server-side parts of the spec's
+// "Clock Skew": the provider can issue a token with a very short
+// lifetime, expires_in reflects the configured lifetime, and an
+// already-expired token is rejected at the resource.
+//
+// PROXY-SIDE: applying an expiry buffer / skew tolerance / refreshing
+// before nominal expiry are all proxy concerns. See
+// docs/integration_test_gaps.md row "scenario-30".
+//
+// Spec: P2 scenario 30.
+func TestScenario30_ClockSkew(t *testing.T) {
+	ts := newTestServer(t)
+	c := registerClient(t, ts, "scn30", "scn30-secret", "https://app.example.com/cb")
+	registerUser(t, ts, "scn30@example.com", "hunter22")
+
+	// Mutate the in-memory config so the next token is issued with a
+	// 1-second access-token lifetime. Each scenario test runs against
+	// its own server instance (fresh config) so this doesn't leak
+	// across scenarios.
+	cnf := ts.OauthService.GetConfig()
+	cnf.Oauth.AccessTokenLifetime = 1
+
+	t.Run("expires_in reflects the configured short lifetime", func(t *testing.T) {
+		_, tok, body := passwordGrant(t, ts, c, "scn30@example.com", "hunter22", "read")
+		if tok.AccessToken == "" {
+			t.Fatalf("setup: missing access token (body=%s)", body)
+		}
+		if tok.ExpiresIn != 1 {
+			t.Fatalf("expected expires_in=1, got %d (body=%s)", tok.ExpiresIn, body)
+		}
+	})
+
+	t.Run("expired token is rejected at the resource", func(t *testing.T) {
+		_, tok, _ := passwordGrant(t, ts, c, "scn30@example.com", "hunter22", "read")
+		// Back-date the just-issued token so the next Authenticate call
+		// rejects it as expired without forcing the test to sleep.
+		expireAccessToken(t, ts, tok.AccessToken)
+
+		status, hdr, body := callResource(t, ts, tok.AccessToken, "/test/resource/foo")
+		if status != http.StatusUnauthorized {
+			t.Fatalf("expected 401 expired, got %d body=%s", status, body)
+		}
+		// Server emits Bearer error="invalid_token" for both expired and
+		// revoked; spot-check the descriptor mentions "expired" so
+		// proxy tests can distinguish.
+		desc := hdr.Get("WWW-Authenticate")
+		if !strings.Contains(strings.ToLower(desc), "expired") {
+			t.Fatalf("WWW-Authenticate should mention expired, got %q", desc)
+		}
+	})
+}

--- a/testmode/authorize.go
+++ b/testmode/authorize.go
@@ -51,10 +51,6 @@ func (s *Service) authorize(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, "client_id is required", http.StatusBadRequest)
 		return
 	}
-	if req.RedirectURI == "" {
-		response.Error(w, "redirect_uri is required", http.StatusBadRequest)
-		return
-	}
 	if req.Decision != "approve" && req.Decision != "deny" {
 		response.Error(w, `decision must be "approve" or "deny"`, http.StatusBadRequest)
 		return
@@ -66,15 +62,22 @@ func (s *Service) authorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate redirect_uri against the registered URI when one is set.
-	if client.RedirectURI.Valid && client.RedirectURI.String != "" {
-		if client.RedirectURI.String != req.RedirectURI {
-			response.Error(w, "redirect_uri does not match registered URI", http.StatusBadRequest)
+	// Resolve redirect_uri: fall back to the client's registered URI
+	// when the request omits it (mirrors /web/authorize behavior). When
+	// both are present, they must match.
+	redirectURI := req.RedirectURI
+	if redirectURI == "" {
+		if !client.RedirectURI.Valid || client.RedirectURI.String == "" {
+			response.Error(w, "redirect_uri is required (client has no registered URI)", http.StatusBadRequest)
 			return
 		}
+		redirectURI = client.RedirectURI.String
+	} else if client.RedirectURI.Valid && client.RedirectURI.String != "" && client.RedirectURI.String != redirectURI {
+		response.Error(w, "redirect_uri does not match registered URI", http.StatusBadRequest)
+		return
 	}
 
-	redirectURL, err := url.Parse(req.RedirectURI)
+	redirectURL, err := url.Parse(redirectURI)
 	if err != nil {
 		response.Error(w, "invalid redirect_uri: "+err.Error(), http.StatusBadRequest)
 		return
@@ -112,7 +115,7 @@ func (s *Service) authorize(w http.ResponseWriter, r *http.Request) {
 		client,
 		user,
 		s.cnf.Oauth.AuthCodeLifetime,
-		req.RedirectURI,
+		redirectURI,
 		resolvedScope,
 		req.CodeChallenge,
 		req.CodeChallengeMethod,


### PR DESCRIPTION
Closes #33. Tracking: #26.

Six P2 scenarios — incremental auth, proxy-initiated disconnect, identity changes, multi-client isolation, open-redirect protection, clock skew. Plus one real bug found during scenario 29.

## Scenarios

### `TestScenario25_IncrementalAuthorization` (P2 #25)

Same user re-authorizes the same client with a broader scope. The new access token has the broader scope; the original access token still works (existing credentials preserved by the upgrade).

Documents a server quirk worth knowing: `GetOrCreateRefreshToken` reuses an existing non-revoked RT for the (client, user) pair rather than minting a new one with the broader scope. Access tokens are independent (one per `Login` call) so the broader-scope assertion holds at the access-token layer; the test does not assert on the second-flow refresh token's scope.

### `TestScenario26_ProxyInitiatedDisconnect` (P2 #26) — 3 subtests

Via `/v1/oauth/revoke`:
- revoking RT cascades to the access token
- unknown-token revoke returns silent 200 per RFC 7009
- cross-client revoke returns silent 200 but does not actually revoke (verified by using the targeted token afterward)

### `TestScenario27_ProviderIdentityChanges` (P2 #27) — 3 subtests

`/test/users/{id}/swap-subject` mutates `sub` mid-session. Same access token sees the new value; clearing the override falls back to the user UUID.

### `TestScenario28_MultipleConnections` (P2 #28) — 2 subtests

Same user authorizing two clients yields independent (access, refresh) chains. Revoking one chain does not touch the other. Cross-client revoke is silent and ineffective.

### `TestScenario29_OpenRedirectProtection` (P2 #29) — 2 subtests

Server-side: `redirect_uri` mismatch is rejected; missing `redirect_uri` falls back to the registered URI. Proxy-side return-URL validation is out of scope and pointed at the gaps doc.

### `TestScenario30_ClockSkew` (P2 #30) — 2 subtests

Mutate `Oauth.AccessTokenLifetime` to 1s, password grant returns `expires_in=1`, back-date the resulting token, resource call returns 401 with an \"expired\" `WWW-Authenticate` descriptor. Proxy-side skew buffering is out of scope and pointed at the gaps doc.

## Bug fix bundled

`/test/authorize` now falls back to the client's registered `redirect_uri` when the request omits it. Previously returned 400. Production `/web/authorize` already had this fallback; test-mode now mirrors that. Caught while writing scenario 29.

## Test plan

- [x] `go build ./... && go vet ./... && gofmt -l .` clean
- [x] `go test ./integration/...` — all 30 scenarios + binary smoke green, ~13s total
- [x] `go test ./testmode/...` — all prior PR subtests still green