### PR TITLE
Per-test scope registration via POST /test/clients

### DIFF
--- a/docs/test_mode_api.md
+++ b/docs/test_mode_api.md
@@ -130,7 +130,7 @@ Register an OAuth client. Test-mode only.
                                                 //   "client_secret_post"
                                                 //   "none"
   "require_pkce": false,                        // optional; auto-set true for `none`
-  "scope": "string"                             // optional; accepted but currently unused
+  "scope": "string"                             // optional; space-delimited list of scope names to register
 }
 ```
 
@@ -145,6 +145,15 @@ clients: a missing `code_challenge` at authorize is rejected, and a
 spurious `code_verifier` at the token endpoint (against a code with
 no stored challenge) is rejected. RFC 7636 §4.5 lax behavior is the
 default for confidential clients.
+
+`scope` is upserted into the global `oauth_scopes` table — each
+whitespace-delimited token becomes a row (`is_default=false`) if not
+already present. Idempotent on the unique `scope` column; declaring
+already-seeded names like `read` is a no-op. This lets tests use
+semantically meaningful scope names (`write`, `admin`, etc.) without
+being limited to the four seeded scopes (`read`, `read_write`,
+`profile`, `email`). Registration is global rather than per-client;
+once a scope exists, any client may request it at `/test/authorize`.
 
 **Response 201**
 

--- a/testmode/handlers.go
+++ b/testmode/handlers.go
@@ -3,11 +3,14 @@ package testmode
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
+	"time"
 
-	"github.com/RichardKnop/go-oauth2-server/log"
+	"github.com/RichardKnop/go-oauth2-server/models"
 	"github.com/RichardKnop/go-oauth2-server/oauth/roles"
 	"github.com/RichardKnop/go-oauth2-server/util"
 	"github.com/RichardKnop/go-oauth2-server/util/response"
+	"github.com/RichardKnop/uuid"
 )
 
 type createClientRequest struct {
@@ -15,7 +18,10 @@ type createClientRequest struct {
 	Secret      string `json:"secret"`
 	RedirectURI string `json:"redirect_uri"`
 
-	// Accepted but not yet enforced; reserved for PR-3.
+	// Scope is a space-delimited list of scope names. Each token is
+	// upserted into oauth_scopes (idempotent on the unique scope
+	// column, is_default=false) so the client may immediately request
+	// it at /test/authorize. Already-seeded scopes are no-ops.
 	Scope string `json:"scope,omitempty"`
 
 	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`
@@ -30,6 +36,37 @@ type clientResponse struct {
 	RequirePKCE             bool   `json:"require_pkce,omitempty"`
 }
 
+// registerScopes upserts each space-delimited token from `raw` into
+// oauth_scopes (idempotent on the unique scope column). Empty input
+// is a no-op. New rows are created with is_default=false; the default
+// flag belongs to the seed.
+//
+// Implementation note: explicit find-then-create rather than gorm v1's
+// FirstOrCreate because FirstOrCreate keys off the destination's
+// primary key when set, and we'd be passing a freshly-generated UUID
+// every call — that misses the already-stored row and the subsequent
+// Create trips the unique constraint on `scope`.
+func (s *Service) registerScopes(raw string) error {
+	for _, tok := range strings.Fields(raw) {
+		var existing models.OauthScope
+		if !s.db.Where("scope = ?", tok).First(&existing).RecordNotFound() {
+			continue
+		}
+		sc := models.OauthScope{
+			MyGormModel: models.MyGormModel{
+				ID:        uuid.New(),
+				CreatedAt: time.Now().UTC(),
+			},
+			Scope:     tok,
+			IsDefault: false,
+		}
+		if err := s.db.Create(&sc).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *Service) createClient(w http.ResponseWriter, r *http.Request) {
 	var req createClientRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -40,9 +77,9 @@ func (s *Service) createClient(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, "key is required", http.StatusBadRequest)
 		return
 	}
-	if req.Scope != "" {
-		log.INFO.Printf("testmode: /test/clients received scope=%q (accepted but not yet enforced; see PR-3)",
-			req.Scope)
+	if err := s.registerScopes(req.Scope); err != nil {
+		response.Error(w, "registering scope: "+err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	client, err := s.oauthService.CreateClient(req.Key, req.Secret, req.RedirectURI, req.TokenEndpointAuthMethod, req.RequirePKCE)

--- a/testmode/integration_test.go
+++ b/testmode/integration_test.go
@@ -164,6 +164,117 @@ func TestTestModeBootstrap(t *testing.T) {
 	})
 }
 
+// TestPerTestScopeRegistration covers issue #44: the `scope` field on
+// POST /test/clients is now an idempotent upsert into oauth_scopes,
+// not a no-op log line. Tests can register arbitrary scope names
+// (write, admin, etc.) instead of being limited to the four seeded
+// scopes (read, read_write, profile, email).
+func TestPerTestScopeRegistration(t *testing.T) {
+	app := newTestApp(t, true)
+	srv := app.server
+
+	registerUser := func(t *testing.T, username, password string) string {
+		t.Helper()
+		buf, _ := json.Marshal(map[string]string{"username": username, "password": password})
+		resp, _ := http.Post(srv.URL+"/test/users", "application/json", bytes.NewReader(buf))
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		var u struct{ ID string }
+		json.Unmarshal(body, &u)
+		return u.ID
+	}
+
+	registerClientWithScope := func(t *testing.T, key, secret, scope string) {
+		t.Helper()
+		buf, _ := json.Marshal(map[string]string{
+			"key":          key,
+			"secret":       secret,
+			"redirect_uri": "https://app.example.com/cb",
+			"scope":        scope,
+		})
+		resp, err := http.Post(srv.URL+"/test/clients", "application/json", bytes.NewReader(buf))
+		if err != nil {
+			t.Fatalf("create client: %v", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("expected 201 creating %q with scope=%q, got %d body=%s", key, scope, resp.StatusCode, body)
+		}
+	}
+
+	authorizeWithScope := func(t *testing.T, clientKey, userID, scope string) (status int, body []byte) {
+		t.Helper()
+		buf, _ := json.Marshal(map[string]any{
+			"client_id":    clientKey,
+			"user_id":      userID,
+			"redirect_uri": "https://app.example.com/cb",
+			"scope":        scope,
+			"decision":     "approve",
+		})
+		resp, err := http.Post(srv.URL+"/test/authorize", "application/json", bytes.NewReader(buf))
+		if err != nil {
+			t.Fatalf("authorize: %v", err)
+		}
+		body, _ = io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return resp.StatusCode, body
+	}
+
+	uid := registerUser(t, "scope-issue-44@example.com", "hunter22")
+
+	t.Run("arbitrary scope names register and become usable at authorize", func(t *testing.T) {
+		// Sanity: before registration, "write" is not in the seed and
+		// authorize must fail.
+		registerClientWithScope(t, "scope-pre", "scope-pre-secret", "")
+		if status, body := authorizeWithScope(t, "scope-pre", uid, "write"); status == http.StatusOK {
+			t.Fatalf("baseline: expected authorize with un-seeded scope=write to fail, got 200 body=%s", body)
+		}
+
+		// Register a client that declares "write" and "admin" in its
+		// scope field. Both should be upserted into oauth_scopes.
+		registerClientWithScope(t, "scope-c1", "scope-c1-secret", "write admin")
+
+		// Now any client (including the previously-registered one) can
+		// authorize with the new scopes — registration is global, not
+		// per-client, since oauth_scopes is a flat table.
+		if status, body := authorizeWithScope(t, "scope-c1", uid, "write"); status != http.StatusOK {
+			t.Fatalf("authorize with newly-registered scope=write expected 200, got %d body=%s", status, body)
+		}
+		if status, body := authorizeWithScope(t, "scope-c1", uid, "admin"); status != http.StatusOK {
+			t.Fatalf("authorize with newly-registered scope=admin expected 200, got %d body=%s", status, body)
+		}
+	})
+
+	t.Run("re-registering the same scope is idempotent", func(t *testing.T) {
+		// Two clients both declaring "write" should both succeed; the
+		// second is a no-op for the scope row but still registers the
+		// client.
+		registerClientWithScope(t, "scope-c2", "scope-c2-secret", "write")
+		registerClientWithScope(t, "scope-c3", "scope-c3-secret", "write admin")
+	})
+
+	t.Run("declaring a seeded scope is a no-op", func(t *testing.T) {
+		// "read" is in the seed; declaring it again must not error.
+		registerClientWithScope(t, "scope-c4", "scope-c4-secret", "read")
+		if status, body := authorizeWithScope(t, "scope-c4", uid, "read"); status != http.StatusOK {
+			t.Fatalf("authorize with seeded scope=read expected 200, got %d body=%s", status, body)
+		}
+	})
+
+	t.Run("multiple whitespace-delimited tokens are handled", func(t *testing.T) {
+		// Mix of new and seeded, with extra whitespace. Each token should
+		// upsert independently; the seeded ones are no-ops.
+		registerClientWithScope(t, "scope-c5", "scope-c5-secret", "  read   custom_a   custom_b ")
+		if status, body := authorizeWithScope(t, "scope-c5", uid, "custom_a"); status != http.StatusOK {
+			t.Fatalf("authorize with custom_a expected 200, got %d body=%s", status, body)
+		}
+		if status, body := authorizeWithScope(t, "scope-c5", uid, "custom_b"); status != http.StatusOK {
+			t.Fatalf("authorize with custom_b expected 200, got %d body=%s", status, body)
+		}
+	})
+}
+
 func TestProductionModeOmitsTestRoutes(t *testing.T) {
 	app := newTestApp(t, false)
 	resp := mustGet(t, app.server.URL+"/test/health")


### PR DESCRIPTION
Closes #44.

The `scope` field on `POST /test/clients` was previously logged as `"accepted but not yet enforced; see PR-3"` and discarded. This PR makes it do what its name implies: register each space-delimited token in the global `oauth_scopes` table so tests can use semantically meaningful names (`write`, `admin`, etc.) instead of being limited to the four seeded scopes (`read`, `read_write`, `profile`, `email`).

## Behavior

- Each whitespace-delimited token in `scope` is upserted into `oauth_scopes` (`is_default=false`) before the client is created.
- Idempotent on the unique `scope` column. Already-seeded names like `read` are no-ops. Re-registering across multiple clients is safe.
- Registration is global rather than per-client (the existing schema is a flat `oauth_scopes` table). Once a scope exists, any client may request it at `/test/authorize`.

## Implementation note worth flagging

Explicit find-then-create rather than gorm v1's `FirstOrCreate`. `FirstOrCreate` keys off the destination's primary key when set, and we'd be passing a freshly-generated UUID every call — that misses the existing row and the subsequent `Create` trips the unique constraint on `scope`. The existing seed pattern only works because the seed runs against a guaranteed-empty database. The find-then-create here is correct under both empty and populated DB states. Documented in a comment on `registerScopes`.

## Non-changes (per the issue's non-requirements)

- Seeded scopes untouched.
- No scope deletion endpoint.
- No new enforcement at the token endpoint — the existing `GetScope` validation at `/web/login` and `/test/authorize` is what gates requests; it Just Works once the row exists.

No alternative `POST /test/scopes` endpoint either — the issue presents it as an alternative, not a complement, and the preferred path covers the stated test need with no client-side change.

## Test plan

- [x] `go build ./... && go vet ./... && gofmt -l .` clean
- [x] `go test ./testmode/...` — 4 new subtests in `TestPerTestScopeRegistration`:
  - arbitrary scope names register and become usable at authorize (with a baseline check that an un-seeded `write` is rejected before registration)
  - re-registering the same scope is idempotent (two clients both declaring `write` both succeed)
  - declaring a seeded scope (`read`) is a no-op
  - whitespace-delimited tokens with extra spaces parse cleanly
- [x] All prior testmode + integration suites still green
- [x] Live smoke: `POST /test/clients {scope: "write admin"}` → `POST /test/authorize {scope: "write"}` returns 200 (was previously 400 invalid_scope); re-registering returns 201