### PR TITLE
[O1] Build and push image to GHCR

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,70 @@
+# schema: https://json.schemastore.org/github-workflow.json
+name: Build Image
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*.*.*']
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: build-image-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/go-oauth2-server
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr,prefix=pr-
+            type=sha,prefix=sha-,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          # arm64 runs under QEMU emulation on amd64 runners — fine for
+          # the merge/tag path but too slow for PR verification. PRs
+          # build amd64 only.
+          platforms: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Adds a workflow that publishes `ghcr.io/rmorlok/go-oauth2-server` on every push to `master`, on PRs, and on `v*.*.*` tags. Downstream consumers (notably AuthProxy's demo and per-branch dev environments) can pin a versioned image instead of building from this repo's source per the docker-compose recipe AuthProxy's integration tests use today.

## What changed

- New `.github/workflows/build-image.yml`
- Multi-arch builds: `linux/amd64` + `linux/arm64` on push-to-master and tags. PRs build amd64 only — arm64 runs under QEMU emulation on the GH-hosted amd64 runner, and that pushes a CGO Go build past the 60-minute job timeout.
- Tag scheme:
  - `master` on default-branch pushes
  - `pr-<num>` on PR builds (same-repo only)
  - `sha-<short>` on every build
  - `vX.Y.Z` and `X.Y` on semver tags
  - `latest` only on `v*.*.*` tags
- GHA layer cache (`type=gha, mode=max`)
- Skips push for PRs from forks (no `packages: write` token there); they still build for verification
- Concurrency: cancels in-progress PR builds on new pushes; master/tag builds run to completion

The existing `ci.yml` (build/vet/gofmt + tests with coverage) is untouched.

## Acceptance check (post-merge)

- [x] Image visible at https://github.com/rmorlok/go-oauth2-server/pkgs/container/go-oauth2-server
- [x] `docker pull ghcr.io/rmorlok/go-oauth2-server:master` succeeds on amd64 and arm64
- [ ] This PR's own build produces a `pr-<num>` tag in the package registry

## Notes

Mirrors the same patterns used in [rmorlok/authproxy#314](https://github.com/rmorlok/authproxy/pull/314) and the arm64-on-PR-timeout fix from [rmorlok/authproxy#325](https://github.com/rmorlok/authproxy/pull/325), so the two repos share a consistent CI build path.

Closes [rmorlok/go-oauth2-server#46](https://github.com/rmorlok/go-oauth2-server/issues/46). Part of [rmorlok/authproxy#284](https://github.com/rmorlok/authproxy/issues/284).