### PR TITLE
OTel #2: Inbound HTTP instrumentation (negroni / gorilla-mux)

### DIFF
--- a/cmd/run_server.go
+++ b/cmd/run_server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/RichardKnop/go-oauth2-server/log"
 	"github.com/RichardKnop/go-oauth2-server/services"
 	"github.com/RichardKnop/go-oauth2-server/telemetry"
+	"github.com/RichardKnop/go-oauth2-server/telemetry/httptelem"
 	"github.com/gorilla/mux"
 	"github.com/phyber/negroni-gzip/gzip"
 	"github.com/urfave/negroni"
@@ -47,6 +48,10 @@ func RunServer(configBackend string) error {
 
 	// Create a router instance
 	router := mux.NewRouter()
+
+	// Telemetry middleware runs inside the mux chain so the matched
+	// route template is available for span naming and metric labels.
+	router.Use(httptelem.Middleware(cnf.Telemetry))
 
 	// Add routes
 	services.HealthService.RegisterRoutes(router, "/v1")

--- a/cmd/run_test_server.go
+++ b/cmd/run_test_server.go
@@ -63,6 +63,7 @@ func RunTestServer(dbPath string, port int) error {
 		services.OauthService,
 		services.WebService,
 		testService,
+		cnf.Telemetry,
 	)
 
 	addr := fmt.Sprintf(":%d", port)

--- a/integration/testenv_test.go
+++ b/integration/testenv_test.go
@@ -65,7 +65,7 @@ func newTestServer(t *testing.T) *testServer {
 	webService := web.NewService(cnf, oauthService, sessionService)
 	testService := testmode.NewService(cnf, db, oauthService)
 
-	handler := testmode.BuildTestApp(healthService, oauthService, webService, testService)
+	handler := testmode.BuildTestApp(healthService, oauthService, webService, testService, cnf.Telemetry)
 	httpSrv := httptest.NewServer(handler)
 
 	ts := &testServer{

--- a/telemetry/httptelem/middleware.go
+++ b/telemetry/httptelem/middleware.go
@@ -1,0 +1,204 @@
+// Package httptelem provides OpenTelemetry instrumentation for inbound HTTP
+// traffic served by gorilla/mux behind negroni.
+//
+// The exported Middleware is a mux.MiddlewareFunc, attached via
+// router.Use(...). Running inside the mux chain means the matched route
+// template is available via mux.CurrentRoute(r), which keeps span and
+// metric cardinality bounded (path parameters don't blow out the
+// dimension set).
+//
+// When telemetry is disabled (cfg.Enabled == false), Middleware returns
+// the next handler unchanged so the request path is identical to the
+// pre-telemetry baseline.
+package httptelem
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/RichardKnop/go-oauth2-server/telemetry"
+	"github.com/gorilla/mux"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/propagation"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// ScopeName identifies the instrumentation library in emitted telemetry.
+const ScopeName = "github.com/RichardKnop/go-oauth2-server/telemetry/httptelem"
+
+// Middleware returns a mux.MiddlewareFunc that records a server span and
+// HTTP RED metrics for every non-excluded inbound request.
+//
+// Span name is the mux route template (e.g. "/v1/oauth/tokens"). 5xx
+// responses mark the span as Error. Panics are recorded as exception
+// events on the span and re-panicked so the negroni Recovery middleware
+// still emits the 500 response.
+//
+// Metrics:
+//
+//	http.server.request.duration  histogram (ms)
+//	http.server.requests          counter
+//	http.server.active_requests   up/down counter
+//
+// duration/requests carry method, route, and response status; the
+// active_requests gauge omits status since the request is still in flight.
+func Middleware(cfg telemetry.Config) mux.MiddlewareFunc {
+	if !cfg.Enabled {
+		return func(next http.Handler) http.Handler { return next }
+	}
+
+	tracer := otel.Tracer(ScopeName)
+	meter := otel.Meter(ScopeName)
+	duration, _ := meter.Float64Histogram(
+		"http.server.request.duration",
+		metric.WithUnit("ms"),
+		metric.WithDescription("Duration of inbound HTTP server requests."),
+	)
+	requests, _ := meter.Int64Counter(
+		"http.server.requests",
+		metric.WithDescription("Count of inbound HTTP server requests."),
+	)
+	active, _ := meter.Int64UpDownCounter(
+		"http.server.active_requests",
+		metric.WithDescription("Number of in-flight inbound HTTP server requests."),
+	)
+	propagator := otel.GetTextMapPropagator()
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if cfg.IsExcluded(r.URL.Path) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			ctx := propagator.Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+
+			route := routeTemplate(r)
+			spanName := route
+			if spanName == "" {
+				spanName = r.Method
+			}
+
+			scheme := r.URL.Scheme
+			if scheme == "" {
+				if r.TLS != nil {
+					scheme = "https"
+				} else {
+					scheme = "http"
+				}
+			}
+
+			startAttrs := []attribute.KeyValue{
+				semconv.HTTPRequestMethodKey.String(r.Method),
+				semconv.URLPath(r.URL.Path),
+				semconv.URLScheme(scheme),
+			}
+			if route != "" {
+				startAttrs = append(startAttrs, semconv.HTTPRoute(route))
+			}
+
+			ctx, span := tracer.Start(ctx, spanName,
+				trace.WithSpanKind(trace.SpanKindServer),
+				trace.WithAttributes(startAttrs...),
+			)
+			defer span.End()
+
+			activeAttrs := metric.WithAttributes(
+				semconv.HTTPRequestMethodKey.String(r.Method),
+				semconv.HTTPRoute(route),
+			)
+			active.Add(ctx, 1, activeAttrs)
+			start := time.Now()
+
+			rw := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+
+			defer func() {
+				active.Add(ctx, -1, activeAttrs)
+
+				if rec := recover(); rec != nil {
+					span.RecordError(panicErr(rec))
+					span.SetStatus(codes.Error, "handler panicked")
+					recordEnd(ctx, duration, requests, start, r.Method, route, http.StatusInternalServerError)
+					panic(rec)
+				}
+
+				recordEnd(ctx, duration, requests, start, r.Method, route, rw.status)
+				span.SetAttributes(semconv.HTTPResponseStatusCode(rw.status))
+				if rw.status >= 500 {
+					span.SetStatus(codes.Error, http.StatusText(rw.status))
+				}
+			}()
+
+			next.ServeHTTP(rw, r.WithContext(ctx))
+		})
+	}
+}
+
+func recordEnd(
+	ctx context.Context,
+	duration metric.Float64Histogram,
+	requests metric.Int64Counter,
+	start time.Time,
+	method, route string,
+	status int,
+) {
+	elapsedMs := float64(time.Since(start)) / float64(time.Millisecond)
+	attrs := metric.WithAttributes(
+		semconv.HTTPRequestMethodKey.String(method),
+		semconv.HTTPRoute(route),
+		semconv.HTTPResponseStatusCode(status),
+	)
+	duration.Record(ctx, elapsedMs, attrs)
+	requests.Add(ctx, 1, attrs)
+}
+
+func routeTemplate(r *http.Request) string {
+	if cr := mux.CurrentRoute(r); cr != nil {
+		if t, err := cr.GetPathTemplate(); err == nil {
+			return t
+		}
+	}
+	return ""
+}
+
+func panicErr(v any) error {
+	if e, ok := v.(error); ok {
+		return e
+	}
+	return fmt.Errorf("panic: %v", v)
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	if !s.wroteHeader {
+		s.status = code
+		s.wroteHeader = true
+	}
+	s.ResponseWriter.WriteHeader(code)
+}
+
+func (s *statusRecorder) Write(b []byte) (int, error) {
+	if !s.wroteHeader {
+		s.wroteHeader = true
+	}
+	return s.ResponseWriter.Write(b)
+}
+
+// Flush forwards to the wrapped writer when it supports flushing so SSE
+// and similar streaming handlers continue to work through the wrapper.
+func (s *statusRecorder) Flush() {
+	if f, ok := s.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}

--- a/telemetry/httptelem/middleware_test.go
+++ b/telemetry/httptelem/middleware_test.go
@@ -317,4 +317,3 @@ func metricSeen(rm metricdata.ResourceMetrics, name string) bool {
 	}
 	return false
 }
-

--- a/telemetry/httptelem/middleware_test.go
+++ b/telemetry/httptelem/middleware_test.go
@@ -1,0 +1,320 @@
+package httptelem
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/telemetry"
+	"github.com/gorilla/mux"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	tracesdk "go.opentelemetry.io/otel/trace"
+)
+
+// setup installs in-memory trace + metric SDKs as the OTel globals so the
+// middleware emits into something this test can inspect, and returns the
+// recorder + reader along with a cleanup func.
+func setup(t *testing.T) (*tracetest.InMemoryExporter, *sdkmetric.ManualReader, func()) {
+	t.Helper()
+	traceExp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(traceExp))
+	otel.SetTracerProvider(tp)
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	otel.SetMeterProvider(mp)
+
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	return traceExp, reader, func() {
+		_ = tp.Shutdown(context.Background())
+		_ = mp.Shutdown(context.Background())
+	}
+}
+
+// buildRouter wires the middleware against the supplied config and returns
+// a mux router with two routes: a parametric /things/{id} that respects
+// the provided handler, and /v1/health for exclusion tests.
+func buildRouter(cfg telemetry.Config, handler http.HandlerFunc) *mux.Router {
+	r := mux.NewRouter()
+	r.Use(Middleware(cfg))
+	r.HandleFunc("/things/{id}", handler).Methods("GET")
+	r.HandleFunc("/v1/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}).Methods("GET")
+	r.HandleFunc("/test/clients", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}).Methods("GET")
+	return r
+}
+
+func enabledCfg() telemetry.Config {
+	c := telemetry.Config{Enabled: true,
+		Exporter: telemetry.Exporter{Protocol: telemetry.ProtocolGRPC, Endpoint: "http://localhost:4317"},
+		Resource: telemetry.Resource{ServiceName: "svc"},
+	}
+	c.ApplyDefaults()
+	return c
+}
+
+func TestMiddleware_EmitsSpanWithRouteTemplate(t *testing.T) {
+	traceExp, reader, cleanup := setup(t)
+	defer cleanup()
+
+	router := buildRouter(enabledCfg(), func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/things/42", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	spans := traceExp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1: %+v", len(spans), spans)
+	}
+	span := spans[0]
+	if span.Name != "/things/{id}" {
+		t.Errorf("span name = %q, want %q", span.Name, "/things/{id}")
+	}
+	if span.SpanKind != tracesdk.SpanKindServer {
+		t.Errorf("span kind = %v, want Server", span.SpanKind)
+	}
+	if !hasAttr(span.Attributes, "http.route", "/things/{id}") {
+		t.Errorf("missing http.route attribute: %+v", span.Attributes)
+	}
+	if !hasAttr(span.Attributes, "http.request.method", "GET") {
+		t.Errorf("missing http.request.method attribute: %+v", span.Attributes)
+	}
+	if !hasAttr(span.Attributes, "url.path", "/things/42") {
+		t.Errorf("missing url.path attribute: %+v", span.Attributes)
+	}
+	if !hasIntAttr(span.Attributes, "http.response.status_code", 200) {
+		t.Errorf("missing http.response.status_code=200: %+v", span.Attributes)
+	}
+
+	// Metrics: duration histogram + requests counter + active=0.
+	got := collect(t, reader)
+	if !metricSeen(got, "http.server.request.duration") {
+		t.Errorf("missing http.server.request.duration in: %v", metricNames(got))
+	}
+	if !metricSeen(got, "http.server.requests") {
+		t.Errorf("missing http.server.requests in: %v", metricNames(got))
+	}
+	if !metricSeen(got, "http.server.active_requests") {
+		t.Errorf("missing http.server.active_requests in: %v", metricNames(got))
+	}
+}
+
+func TestMiddleware_5xxMarksSpanError(t *testing.T) {
+	traceExp, _, cleanup := setup(t)
+	defer cleanup()
+
+	router := buildRouter(enabledCfg(), func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/things/abc", nil)
+	router.ServeHTTP(httptest.NewRecorder(), req)
+
+	spans := traceExp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	if spans[0].Status.Code.String() != "Error" {
+		t.Errorf("span status code = %v, want Error", spans[0].Status.Code)
+	}
+	if !hasIntAttr(spans[0].Attributes, "http.response.status_code", 500) {
+		t.Errorf("status_code attr missing/wrong: %+v", spans[0].Attributes)
+	}
+}
+
+func TestMiddleware_PanicRecordedAndRepanicked(t *testing.T) {
+	traceExp, _, cleanup := setup(t)
+	defer cleanup()
+
+	router := buildRouter(enabledCfg(), func(http.ResponseWriter, *http.Request) {
+		panic(errors.New("boom"))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/things/x", nil)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected re-panic, got none")
+		}
+
+		spans := traceExp.GetSpans()
+		if len(spans) != 1 {
+			t.Fatalf("got %d spans, want 1", len(spans))
+		}
+		if spans[0].Status.Code.String() != "Error" {
+			t.Errorf("span status code = %v, want Error", spans[0].Status.Code)
+		}
+		// RecordError adds an "exception" event.
+		foundException := false
+		for _, ev := range spans[0].Events {
+			if ev.Name == "exception" {
+				foundException = true
+				break
+			}
+		}
+		if !foundException {
+			t.Errorf("no exception event recorded: %+v", spans[0].Events)
+		}
+	}()
+
+	router.ServeHTTP(httptest.NewRecorder(), req)
+}
+
+func TestMiddleware_ExcludedPathEmitsNothing(t *testing.T) {
+	traceExp, reader, cleanup := setup(t)
+	defer cleanup()
+
+	router := buildRouter(enabledCfg(), func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+	router.ServeHTTP(httptest.NewRecorder(), req)
+
+	if spans := traceExp.GetSpans(); len(spans) != 0 {
+		t.Errorf("got %d spans for excluded path, want 0", len(spans))
+	}
+	got := collect(t, reader)
+	if metricSeen(got, "http.server.request.duration") {
+		t.Errorf("duration histogram should be absent for excluded path; metrics: %v", metricNames(got))
+	}
+}
+
+func TestMiddleware_TestPathIsNotExcluded(t *testing.T) {
+	traceExp, _, cleanup := setup(t)
+	defer cleanup()
+
+	router := buildRouter(enabledCfg(), func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test/clients", nil)
+	router.ServeHTTP(httptest.NewRecorder(), req)
+
+	spans := traceExp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans for /test/clients, want 1 (load tests need this visible)", len(spans))
+	}
+	if spans[0].Name != "/test/clients" {
+		t.Errorf("span name = %q, want %q", spans[0].Name, "/test/clients")
+	}
+}
+
+func TestMiddleware_HonorsIncomingTraceparent(t *testing.T) {
+	traceExp, _, cleanup := setup(t)
+	defer cleanup()
+
+	router := buildRouter(enabledCfg(), func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/things/foo", nil)
+	// 32-hex trace-id, 16-hex span-id, sampled.
+	wantTraceID := "0123456789abcdef0123456789abcdef"
+	req.Header.Set("traceparent", "00-"+wantTraceID+"-fedcba9876543210-01")
+
+	router.ServeHTTP(httptest.NewRecorder(), req)
+
+	spans := traceExp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	gotTraceID := spans[0].SpanContext.TraceID().String()
+	if gotTraceID != wantTraceID {
+		t.Errorf("trace id = %q, want %q (incoming traceparent not honored)", gotTraceID, wantTraceID)
+	}
+	if !spans[0].Parent.IsValid() {
+		t.Errorf("parent span context is invalid; want valid from incoming traceparent")
+	}
+}
+
+func TestMiddleware_DisabledIsPassThrough(t *testing.T) {
+	traceExp, reader, cleanup := setup(t)
+	defer cleanup()
+
+	cfg := telemetry.Config{Enabled: false}
+	router := mux.NewRouter()
+	router.Use(Middleware(cfg))
+	router.HandleFunc("/x", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	router.ServeHTTP(httptest.NewRecorder(), req)
+
+	if spans := traceExp.GetSpans(); len(spans) != 0 {
+		t.Errorf("disabled middleware emitted %d spans", len(spans))
+	}
+	if names := metricNames(collect(t, reader)); len(names) != 0 {
+		t.Errorf("disabled middleware emitted metrics: %v", names)
+	}
+}
+
+// helpers
+
+func hasAttr(attrs []attribute.KeyValue, key, want string) bool {
+	for _, kv := range attrs {
+		if string(kv.Key) == key && kv.Value.AsString() == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasIntAttr(attrs []attribute.KeyValue, key string, want int64) bool {
+	for _, kv := range attrs {
+		if string(kv.Key) == key && kv.Value.AsInt64() == want {
+			return true
+		}
+	}
+	return false
+}
+
+func collect(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("metric collect: %v", err)
+	}
+	return rm
+}
+
+func metricNames(rm metricdata.ResourceMetrics) []string {
+	var out []string
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			out = append(out, m.Name)
+		}
+	}
+	return out
+}
+
+func metricSeen(rm metricdata.ResourceMetrics, name string) bool {
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+

--- a/testmode/app.go
+++ b/testmode/app.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/RichardKnop/go-oauth2-server/health"
 	"github.com/RichardKnop/go-oauth2-server/oauth"
+	"github.com/RichardKnop/go-oauth2-server/telemetry"
+	"github.com/RichardKnop/go-oauth2-server/telemetry/httptelem"
 	"github.com/RichardKnop/go-oauth2-server/web"
 	"github.com/gorilla/mux"
 	"github.com/urfave/negroni"
@@ -38,6 +40,7 @@ func BuildTestApp(
 	oauthService oauth.ServiceInterface,
 	webService web.ServiceInterface,
 	testService *Service,
+	telemetryCfg telemetry.Config,
 ) http.Handler {
 	app := negroni.New()
 	app.Use(negroni.NewRecovery())
@@ -47,6 +50,10 @@ func BuildTestApp(
 	app.Use(negroni.NewStatic(http.Dir("public")))
 
 	router := mux.NewRouter()
+	// Telemetry middleware runs inside the mux chain so the matched
+	// route template is available for span naming and metric labels.
+	router.Use(httptelem.Middleware(telemetryCfg))
+
 	healthService.RegisterRoutes(router, "/v1")
 	oauthService.RegisterRoutes(router, "/v1/oauth")
 	webService.RegisterRoutes(router, "/web")


### PR DESCRIPTION
## Summary
- Add `telemetry/httptelem.Middleware` as a `mux.MiddlewareFunc` — running inside the mux chain means `mux.CurrentRoute(r)` is available, so the matched route template becomes the span name and the `http.route` metric dimension (path parameters can't blow out cardinality).
- Wire it into both `cmd.RunServer` and `testmode.BuildTestApp`. `BuildTestApp` gains a `telemetry.Config` parameter — the two callers (`cmd.RunTestServer`, `integration/testenv_test.go`) thread `cnf.Telemetry` through.
- Emits one server span (kind=Server, semconv 1.40 attrs) per non-excluded request, plus three RED metrics: `http.server.request.duration` (histogram, ms), `http.server.requests` (counter), `http.server.active_requests` (up/down counter).
- 5xx responses mark the span `Error`. Panics record an exception event on the span and re-panic so the existing negroni Recovery still emits the 500.
- Honors incoming W3C `traceparent` via the global propagator (set in OTel #1).
- `/v1/health` excluded by default; `/test/*` is intentionally **not** excluded — load tests against the test-mode harness should see those endpoints.
- When telemetry is disabled (`cfg.Enabled == false`), `Middleware` returns the next handler unchanged. True zero-overhead pass-through.

Refs #49, #47.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./telemetry/...` — covers route template span naming, 5xx → Error, panic → exception event + re-panic, `/v1/health` excluded, `/test/*` not excluded, incoming `traceparent` honored, disabled middleware emits nothing
- [x] `go test ./...` — passing aside from the pre-existing `oauth/` suite that requires the `postgres` docker hostname (reproduces on `master`)
- [ ] Manual: run with a Collector, hit `/v1/oauth/tokens` and `/test/clients`, verify spans/metrics appear with route templates and correct dimensions
- [ ] Manual: panic via a debug endpoint, verify span carries `exception` event and the 500 response still ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)