### PR TITLE
OTel #3: Database (Postgres + SQLite) instrumentation under GORM v1

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/RichardKnop/go-oauth2-server/config"
+	"github.com/RichardKnop/go-oauth2-server/telemetry/dbtelem"
 	"github.com/jinzhu/gorm"
 
 	// Drivers
@@ -20,10 +21,14 @@ func init() {
 
 // NewDatabase returns a gorm.DB struct, gorm.DB.DB() returns a database handle
 // see http://golang.org/pkg/database/sql/#DB
+//
+// Connection opening goes through telemetry/dbtelem so every SQL call flows
+// through an OTel-instrumented wrapper when cnf.Telemetry.Enabled is true.
+// GORM v1 accepts a *sql.DB as its source, so the wrapper sits transparently
+// beneath the dialect-specific SQL generator.
 func NewDatabase(cnf *config.Config) (*gorm.DB, error) {
-	// Postgres
-	if cnf.Database.Type == "postgres" {
-		// Connection args
+	switch cnf.Database.Type {
+	case "postgres":
 		// see https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters
 		args := fmt.Sprintf(
 			"sslmode=disable host=%s port=%d user=%s password='%s' dbname=%s",
@@ -34,27 +39,39 @@ func NewDatabase(cnf *config.Config) (*gorm.DB, error) {
 			cnf.Database.DatabaseName,
 		)
 
-		db, err := gorm.Open(cnf.Database.Type, args)
+		sqlDB, err := dbtelem.Open(cnf.Telemetry, "postgres", args, "postgresql")
+		if err != nil {
+			return nil, err
+		}
+
+		db, err := gorm.Open("postgres", sqlDB)
 		if err != nil {
 			return db, err
 		}
 
-		// Max idle connections
 		db.DB().SetMaxIdleConns(cnf.Database.MaxIdleConns)
-
-		// Max open connections
 		db.DB().SetMaxOpenConns(cnf.Database.MaxOpenConns)
-
-		// Database logging
 		db.LogMode(cnf.IsDevelopment)
 
+		if err := dbtelem.RegisterPoolMetrics(cnf.Telemetry, db.DB(), "postgresql"); err != nil {
+			return db, err
+		}
 		return db, nil
-	}
 
-	// SQLite
-	if cnf.Database.Type == "sqlite3" {
+	case "sqlite3":
 		// cnf.Database.DatabaseName carries the file path or ":memory:"
-		db, err := gorm.Open("sqlite3", cnf.Database.DatabaseName)
+		sqlDB, err := dbtelem.Open(cnf.Telemetry, "sqlite3", cnf.Database.DatabaseName, "sqlite")
+		if err != nil {
+			return nil, err
+		}
+
+		// SQLite serializes writes anyway; with ":memory:" each pooled
+		// connection would also get its own private database, which makes
+		// concurrent test traffic see partial state. Cap the pool at 1
+		// before any query lands so PRAGMA and migrations share the DB.
+		sqlDB.SetMaxOpenConns(1)
+
+		db, err := gorm.Open("sqlite3", sqlDB)
 		if err != nil {
 			return db, err
 		}
@@ -64,16 +81,13 @@ func NewDatabase(cnf *config.Config) (*gorm.DB, error) {
 			return db, err
 		}
 
-		// SQLite serializes writes anyway; with ":memory:" each pooled
-		// connection would also get its own private database, which makes
-		// concurrent test traffic see partial state. Cap the pool at 1 so
-		// every query lands on the same connection and the same DB.
-		db.DB().SetMaxOpenConns(1)
-
 		db.LogMode(cnf.IsDevelopment)
+
+		if err := dbtelem.RegisterPoolMetrics(cnf.Telemetry, db.DB(), "sqlite"); err != nil {
+			return db, err
+		}
 		return db, nil
 	}
 
-	// Database type not supported
 	return nil, fmt.Errorf("Database type %s not suppported", cnf.Database.Type)
 }

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 )
 
 require (
+	github.com/XSAM/otelsql v0.42.0 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/RichardKnop/logging v0.0.0-20181101035820-b1d5d44c82d6 h1:Vgjpn7q8aQn
 github.com/RichardKnop/logging v0.0.0-20181101035820-b1d5d44c82d6/go.mod h1:rJJ84PyA/Wlmw1hO+xTzV2wsSUon6J5ktg0g8BF2PuU=
 github.com/RichardKnop/uuid v0.0.0-20160216163710-c55201b03606 h1:HEadFvevCuszAyk2FHtjJiMhBDNp8eVC2P+8yAGt368=
 github.com/RichardKnop/uuid v0.0.0-20160216163710-c55201b03606/go.mod h1:a1zbGw9XTxfXn9AzJpparUXoLyawRZdcA//hyAtXLeU=
+github.com/XSAM/otelsql v0.42.0 h1:Li0xF4eJUxG2e0x3D4rvRlys1f27yJKvjTh7ljkUP5o=
+github.com/XSAM/otelsql v0.42.0/go.mod h1:4mOrEv+cS1KmKzrvTktvJnstr5GtKSAK+QHvFR9OcpI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/telemetry/config.go
+++ b/telemetry/config.go
@@ -35,7 +35,16 @@ type Config struct {
 	Sampling Sampling `json:"sampling"`
 	Signals  Signals  `json:"signals"`
 	HTTP     HTTP     `json:"http"`
+	Database Database `json:"database,omitempty"`
 	Shutdown Shutdown `json:"shutdown"`
+}
+
+// Database holds telemetry settings specific to database/sql instrumentation.
+type Database struct {
+	// DisableStatement omits db.statement from emitted spans entirely.
+	// Useful for deployments where even parameterized SQL is considered
+	// sensitive. Bind values are never captured regardless of this setting.
+	DisableStatement bool `json:"disable_statement,omitempty"`
 }
 
 // Exporter describes the OTLP exporter configuration. Empty fields are

--- a/telemetry/dbtelem/dbtelem.go
+++ b/telemetry/dbtelem/dbtelem.go
@@ -1,0 +1,67 @@
+// Package dbtelem opens an OTel-instrumented *sql.DB for the application's
+// database connections. It is a thin convenience wrapper around
+// github.com/XSAM/otelsql that:
+//
+//   - returns a plain (un-instrumented) *sql.DB when telemetry is disabled,
+//     so the disabled path is identical to the pre-telemetry baseline;
+//   - applies sensible defaults for go-oauth2-server (semconv 1.40 db.system
+//     attribute, query captured by default with bind values never recorded);
+//   - exposes RegisterPoolMetrics so callers can attach db.client.connections
+//     gauges after the pool size has been configured.
+//
+// The returned *sql.DB is intended to be handed to GORM v1 via
+// gorm.Open(dialect, sqlDB); GORM continues to drive the dialect-specific
+// SQL while every driver call flows through the otelsql wrapper.
+package dbtelem
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/RichardKnop/go-oauth2-server/telemetry"
+	"github.com/XSAM/otelsql"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+)
+
+// Open opens a *sql.DB for driverName / dsn. When cfg.Enabled is true the
+// connection is wrapped by otelsql with semconv attributes; otherwise a
+// plain sql.Open is returned so disabled-telemetry deployments see zero
+// behavioral change.
+//
+// dbSystem is one of the semconv db.system values ("postgresql", "sqlite",
+// etc.) and is attached to every emitted span and metric so dashboards
+// can split by backend.
+func Open(cfg telemetry.Config, driverName, dsn, dbSystem string) (*sql.DB, error) {
+	if !cfg.Enabled {
+		return sql.Open(driverName, dsn)
+	}
+
+	opts := []otelsql.Option{
+		otelsql.WithAttributes(semconv.DBSystemNameKey.String(dbSystem)),
+		otelsql.WithSpanOptions(otelsql.SpanOptions{
+			DisableQuery: cfg.Database.DisableStatement,
+		}),
+	}
+	db, err := otelsql.Open(driverName, dsn, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("dbtelem: open %s: %w", driverName, err)
+	}
+	return db, nil
+}
+
+// RegisterPoolMetrics attaches db.client.connections.* gauges to db. It is
+// a no-op (returning nil) when telemetry is disabled.
+//
+// dbSystem and any extra attributes are added to every emitted measurement
+// so multiple pools can be distinguished.
+func RegisterPoolMetrics(cfg telemetry.Config, db *sql.DB, dbSystem string, extra ...attribute.KeyValue) error {
+	if !cfg.Enabled {
+		return nil
+	}
+	attrs := append([]attribute.KeyValue{semconv.DBSystemNameKey.String(dbSystem)}, extra...)
+	if _, err := otelsql.RegisterDBStatsMetrics(db, otelsql.WithAttributes(attrs...)); err != nil {
+		return fmt.Errorf("dbtelem: register pool metrics: %w", err)
+	}
+	return nil
+}

--- a/telemetry/dbtelem/dbtelem_test.go
+++ b/telemetry/dbtelem/dbtelem_test.go
@@ -1,0 +1,258 @@
+package dbtelem_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/RichardKnop/go-oauth2-server/telemetry"
+	"github.com/RichardKnop/go-oauth2-server/telemetry/dbtelem"
+
+	_ "github.com/mattn/go-sqlite3"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// setup installs in-memory trace + metric SDKs as OTel globals so the
+// dbtelem wrapper emits into something this test can inspect.
+func setup(t *testing.T) (*tracetest.InMemoryExporter, *sdkmetric.ManualReader, func()) {
+	t.Helper()
+	traceExp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(traceExp))
+	otel.SetTracerProvider(tp)
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	otel.SetMeterProvider(mp)
+
+	return traceExp, reader, func() {
+		_ = tp.Shutdown(context.Background())
+		_ = mp.Shutdown(context.Background())
+	}
+}
+
+func enabledCfg() telemetry.Config {
+	c := telemetry.Config{Enabled: true,
+		Exporter: telemetry.Exporter{Protocol: telemetry.ProtocolGRPC, Endpoint: "http://localhost:4317"},
+		Resource: telemetry.Resource{ServiceName: "svc"},
+	}
+	c.ApplyDefaults()
+	return c
+}
+
+func TestOpen_EnabledEmitsSpansWithDBSystem(t *testing.T) {
+	traceExp, _, cleanup := setup(t)
+	defer cleanup()
+
+	db, err := dbtelem.Open(enabledCfg(), "sqlite3", ":memory:", "sqlite")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.ExecContext(context.Background(), "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), "INSERT INTO t (name) VALUES ('a')"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	spans := traceExp.GetSpans()
+	if len(spans) == 0 {
+		t.Fatalf("got 0 spans, want at least 1")
+	}
+
+	// At least one span carries db.system=sqlite. We also expect db.statement
+	// to be present (default capture-without-bind-values behaviour).
+	var sawDBSystem, sawStatement bool
+	for _, sp := range spans {
+		for _, a := range sp.Attributes {
+			switch string(a.Key) {
+			case "db.system.name", "db.system":
+				if a.Value.AsString() == "sqlite" {
+					sawDBSystem = true
+				}
+			case "db.statement", "db.query.text":
+				if strings.Contains(a.Value.AsString(), "INSERT") || strings.Contains(a.Value.AsString(), "CREATE") {
+					sawStatement = true
+				}
+			}
+		}
+	}
+	if !sawDBSystem {
+		t.Errorf("no span carried db.system=sqlite; spans=%+v", spans)
+	}
+	if !sawStatement {
+		t.Errorf("expected db.statement to be captured by default; spans=%+v", spans)
+	}
+}
+
+func TestOpen_FailingQueryRecordsErrorOnSpan(t *testing.T) {
+	traceExp, _, cleanup := setup(t)
+	defer cleanup()
+
+	db, err := dbtelem.Open(enabledCfg(), "sqlite3", ":memory:", "sqlite")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	// Reference a table that doesn't exist so the driver returns an error.
+	_, _ = db.ExecContext(context.Background(), "SELECT * FROM nope_does_not_exist")
+
+	sawError := false
+	for _, sp := range traceExp.GetSpans() {
+		if sp.Status.Code.String() == "Error" {
+			sawError = true
+			break
+		}
+		for _, ev := range sp.Events {
+			if ev.Name == "exception" {
+				sawError = true
+				break
+			}
+		}
+	}
+	if !sawError {
+		t.Errorf("expected at least one span to record the query error; spans=%+v", traceExp.GetSpans())
+	}
+}
+
+func TestOpen_DisableStatementOmitsQuery(t *testing.T) {
+	traceExp, _, cleanup := setup(t)
+	defer cleanup()
+
+	cfg := enabledCfg()
+	cfg.Database.DisableStatement = true
+
+	db, err := dbtelem.Open(cfg, "sqlite3", ":memory:", "sqlite")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.ExecContext(context.Background(), "CREATE TABLE t (id INTEGER PRIMARY KEY)"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	for _, sp := range traceExp.GetSpans() {
+		for _, a := range sp.Attributes {
+			if string(a.Key) == "db.statement" || string(a.Key) == "db.query.text" {
+				t.Errorf("DisableStatement=true: span %q still has %s=%q", sp.Name, a.Key, a.Value.AsString())
+			}
+		}
+	}
+}
+
+func TestOpen_DisabledReturnsPlainDB(t *testing.T) {
+	traceExp, reader, cleanup := setup(t)
+	defer cleanup()
+
+	cfg := telemetry.Config{Enabled: false}
+
+	db, err := dbtelem.Open(cfg, "sqlite3", ":memory:", "sqlite")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.ExecContext(context.Background(), "CREATE TABLE t (id INTEGER PRIMARY KEY)"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if spans := traceExp.GetSpans(); len(spans) != 0 {
+		t.Errorf("disabled telemetry emitted %d spans, want 0", len(spans))
+	}
+	if names := metricNames(collect(t, reader)); len(names) != 0 {
+		t.Errorf("disabled telemetry emitted metrics %v, want none", names)
+	}
+}
+
+func TestRegisterPoolMetrics_EmitsConnectionGauges(t *testing.T) {
+	_, reader, cleanup := setup(t)
+	defer cleanup()
+
+	db, err := dbtelem.Open(enabledCfg(), "sqlite3", ":memory:", "sqlite")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	if err := dbtelem.RegisterPoolMetrics(enabledCfg(), db, "sqlite", attribute.String("pool", "primary")); err != nil {
+		t.Fatalf("RegisterPoolMetrics: %v", err)
+	}
+
+	// Force the pool to materialize at least one connection so the gauges
+	// have something to report.
+	if err := db.PingContext(context.Background()); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+
+	// XSAM/otelsql emits pool metrics under db.sql.connection.* names
+	// rather than the semconv db.client.connections.* names. Verify that
+	// at least the core "open" and "max_open" gauges are present.
+	rm := collect(t, reader)
+	want := []string{"db.sql.connection.open", "db.sql.connection.max_open"}
+	for _, name := range want {
+		if !metricSeen(rm, name) {
+			t.Errorf("missing %q in pool metrics: %v", name, metricNames(rm))
+		}
+	}
+}
+
+func TestRegisterPoolMetrics_DisabledIsNoOp(t *testing.T) {
+	_, reader, cleanup := setup(t)
+	defer cleanup()
+
+	cfg := telemetry.Config{Enabled: false}
+	db, err := dbtelem.Open(cfg, "sqlite3", ":memory:", "sqlite")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	if err := dbtelem.RegisterPoolMetrics(cfg, db, "sqlite"); err != nil {
+		t.Errorf("RegisterPoolMetrics(disabled) returned %v, want nil", err)
+	}
+	if err := db.PingContext(context.Background()); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+
+	if names := metricNames(collect(t, reader)); len(names) != 0 {
+		t.Errorf("disabled pool metrics emitted %v, want none", names)
+	}
+}
+
+// helpers
+
+func collect(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("metric collect: %v", err)
+	}
+	return rm
+}
+
+func metricNames(rm metricdata.ResourceMetrics) []string {
+	var out []string
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			out = append(out, m.Name)
+		}
+	}
+	return out
+}
+
+func metricSeen(rm metricdata.ResourceMetrics, name string) bool {
+	for _, n := range metricNames(rm) {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Open every connection through `telemetry/dbtelem.Open`, which wraps `database/sql` via `github.com/XSAM/otelsql` when telemetry is enabled and falls back to a plain `sql.Open` when disabled — true zero-cost pass-through.
- GORM v1.9.16 accepts a `*sql.DB` directly, so `gorm.Open(dialect, sqlDB)` keeps the dialect-specific SQL generator intact while every driver call flows through the instrumented wrapper. No GORM v2 migration needed.
- Pool gauges (`db.sql.connection.open` / `max_open` / `wait` / ...) registered on the same `*sql.DB` after pool size is set, via `otelsql.RegisterDBStatsMetrics`.
- New `telemetry.Database.DisableStatement` config knob — deployments where even parameterized SQL is considered sensitive can opt out of `db.statement` capture entirely. Bind values are never captured regardless.
- Spans carry `db.system` (`postgresql` / `sqlite`), `db.statement` (default on, opt-out), and operation/table where otelsql can derive them. Failing queries set the span status to Error.

Refs #50, #47.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go test ./telemetry/...` — covers query span emission with `db.system`, default statement capture, statement-disable knob, error capture, pool gauge registration, disabled = no telemetry / no metrics
- [x] `go test ./database/ ./testmode/ ./integration/` — full integration tests exercise the wrapped DB end-to-end through gorm
- [x] `go test ./...` — passing aside from the pre-existing `oauth/` suite that requires the `postgres` docker hostname (reproduces on `master`)
- [ ] Manual: run with a Collector against Postgres, verify spans include the expected attributes and pool gauges populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)