### PR TITLE
OTel #7: Dev observability stack via docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,55 @@ During `docker-compose up` process all configuration and fixtures will be loaded
 curl --compressed -v localhost:8080/v1/health
 ```
 
+### Local observability stack (optional)
+
+`docker-compose.yml` ships an opt-in `observability` profile that brings up
+[`grafana/otel-lgtm`](https://github.com/grafana/docker-otel-lgtm) — a
+single container bundling Grafana, Tempo (traces), Loki (logs),
+Prometheus (metrics), and a pre-wired OpenTelemetry Collector.
+
+```sh
+docker compose --profile observability up -d otel_lgtm
+```
+
+- Grafana UI: <http://localhost:3001> (login `admin` / `admin`).
+- OTLP gRPC: `localhost:4317`
+- OTLP HTTP: `localhost:4318`
+
+Default `docker compose up -d` is unchanged — the observability stack
+only runs when you pass `--profile observability`.
+
+To point the app at the local Collector, enable telemetry in the config
+(via env vars on a `go run` or in your etcd/consul payload):
+
+```sh
+OTEL_SERVICE_NAME=go-oauth2-server \
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+  go run . runserver --test-mode
+```
+
+If you're loading config from etcd/consul, the equivalent JSON block is:
+
+```json
+{
+  "Telemetry": {
+    "Enabled": true,
+    "Exporter": {
+      "Protocol": "grpc",
+      "Endpoint": "http://localhost:4317",
+      "Insecure": true
+    },
+    "Resource": { "ServiceName": "go-oauth2-server" }
+  }
+}
+```
+
+A pre-provisioned **go-oauth2-server overview** dashboard is included
+under the `go-oauth2-server` folder in Grafana. It surfaces HTTP request
+rate / latency / errors by route, OAuth token issuance by grant type and
+outcome, recent OAuth traces from Tempo, and application logs from Loki.
+
 ## Supporting the project
 
 Donate BTC to my wallet if you find this project useful: `12iFVjQ5n3Qdmiai4Mp9EG93NSvDipyRKV`

--- a/deploy/observability/grafana/dashboards/dashboards.yml
+++ b/deploy/observability/grafana/dashboards/dashboards.yml
@@ -1,0 +1,19 @@
+apiVersion: 1
+
+# Grafana dashboard provisioning for the local observability stack.
+#
+# The grafana/otel-lgtm image scans this directory for both .yml provider
+# configs and the JSON dashboards they reference. Mount the parent dir
+# (deploy/observability/grafana/dashboards) into the container at
+# /otel-lgtm/grafana/conf/provisioning/dashboards via docker-compose.
+providers:
+  - name: "go-oauth2-server"
+    orgId: 1
+    folder: "go-oauth2-server"
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /otel-lgtm/grafana/conf/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/deploy/observability/grafana/dashboards/oauth2-server-overview.json
+++ b/deploy/observability/grafana/dashboards/oauth2-server-overview.json
@@ -1,0 +1,413 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Default development dashboard for go-oauth2-server. Bundled with the docker-compose observability profile; populated by the grafana/otel-lgtm stack when the app is configured to export to http://localhost:4317.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_requests_total[5m])) by (http_route)",
+          "legendFormat": "{{http_route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP request rate by route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_milliseconds_bucket[5m])) by (le, http_route))",
+          "legendFormat": "p95 {{http_route}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_milliseconds_bucket[5m])) by (le, http_route))",
+          "legendFormat": "p50 {{http_route}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "HTTP request duration (p50 / p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 1,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_requests_total{http_response_status_code=~\"5..\"}[5m])) by (http_route)",
+          "legendFormat": "5xx {{http_route}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_requests_total{http_response_status_code=~\"4..\"}[5m])) by (http_route)",
+          "legendFormat": "4xx {{http_route}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "HTTP errors (4xx / 5xx) by route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 1,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(oauth_token_issued_total[5m])) by (oauth_grant_type, outcome)",
+          "legendFormat": "{{oauth_grant_type}} / {{outcome}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "OAuth tokens issued by grant_type / outcome",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "tempo"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "limit": 20,
+          "query": "{ resource.service.name = \"go-oauth2-server\" && name =~ \"oauth.*\" }",
+          "queryType": "traceql",
+          "refId": "A",
+          "tableType": "traces"
+        }
+      ],
+      "title": "Recent OAuth traces (Tempo)",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 6,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "{service_name=\"go-oauth2-server\"} | json",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Application logs (Loki)",
+      "type": "logs"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["go-oauth2-server", "otel"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "go-oauth2-server overview",
+  "uid": "go-oauth2-server-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,37 @@ services:
       - postgres
     command: ["loaddata", "oauth/fixtures/test_clients.yml"]
 
+  # Local observability stack — opt-in via the "observability" profile.
+  #
+  # Brings up grafana/otel-lgtm, an all-in-one image bundling Grafana,
+  # Tempo (traces), Loki (logs), Prometheus (metrics) and an OTel
+  # Collector. The Collector listens on 4317 (gRPC) and 4318 (HTTP),
+  # both exposed on the host so a local `go run` of the app can target
+  # them without going through Docker networking.
+  #
+  # Activate with:
+  #
+  #   docker compose --profile observability up -d otel_lgtm
+  #
+  # Default `docker compose up -d` leaves this off.
+  #
+  # Grafana is published on host port 3001 (mapped to in-container 3000)
+  # to avoid collisions with anything else the contributor may have on
+  # 3000. Tempo / Loki / Prometheus data sources are auto-provisioned by
+  # the image. We mount one custom dashboard ("go-oauth2-server overview")
+  # that shows HTTP RED metrics, OAuth token issuance, and Tempo trace
+  # search wired to this service.
+  otel_lgtm:
+    image: grafana/otel-lgtm:latest
+    container_name: go_oauth2_server_otel_lgtm
+    profiles: ["observability"]
+    ports:
+      - "3001:3000"   # Grafana UI -> http://localhost:3001 (admin/admin)
+      - "4317:4317"   # OTLP gRPC
+      - "4318:4318"   # OTLP HTTP/protobuf
+    volumes:
+      - "./deploy/observability/grafana/dashboards:/otel-lgtm/grafana/conf/provisioning/dashboards:ro"
+
 volumes:
   etcd-data:
   db-data:


### PR DESCRIPTION
## Summary
- Opt-in \`observability\` profile in \`docker-compose.yml\` that runs \`grafana/otel-lgtm\` — a single container bundling Grafana, Tempo (traces), Loki (logs), Prometheus (metrics), and a pre-wired OTel Collector.
- Default \`docker compose up -d\` is **unchanged**. Activate with \`docker compose --profile observability up -d otel_lgtm\`.
- Grafana exposed on host port **3001** to avoid colliding with anything else on 3000. OTLP gRPC on 4317, HTTP on 4318. Tempo / Loki / Prometheus data sources auto-provisioned by the image.
- Custom \"go-oauth2-server overview\" dashboard (\`deploy/observability/grafana/dashboards/oauth2-server-overview.json\`) mounted into the container, surfacing:
  - HTTP request rate by route
  - HTTP duration p50/p95 by route (from the \`http.server.request.duration\` histogram)
  - HTTP 4xx / 5xx by route
  - OAuth token issuance by \`grant_type\` + \`outcome\`
  - Recent OAuth traces via Tempo TraceQL
  - Application logs via Loki
- README gets a **Local observability stack** section documenting the profile, the env-var override that enables telemetry against the bundled Collector, and the equivalent etcd/consul JSON snippet.

Refs #54, #47.

## Test plan
- [x] \`docker compose config --services\` — unchanged (5 services: app, app_testdata, etcd, etcd_config, postgres)
- [x] \`docker compose --profile observability config --services\` — adds \`otel_lgtm\`
- [x] dashboard JSON parses cleanly
- [x] \`go build ./... && go vet ./...\` clean; \`gofmt -l .\` clean
- [x] \`go test ./...\` passes aside from the pre-existing \`oauth/\` suite that requires the \`postgres\` docker hostname (reproduces on master)
- [ ] Manual: \`docker compose --profile observability up -d otel_lgtm\`, point \`go run\` at \`localhost:4317\`, exercise some endpoints, verify dashboard populates and Tempo trace search returns oauth.* spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)