### PR TITLE
Add test-mode API-key resource endpoint

### DIFF
--- a/docs/test_mode_api.md
+++ b/docs/test_mode_api.md
@@ -42,6 +42,8 @@ behavior toggles.
 - [Resource server](#resource-server)
   - [`ANY /test/resource/{path}`](#any-testresourcepath)
   - [`POST /test/resource-policy`](#post-testresource-policy)
+  - [`ANY /test/api-key-resource/{path}`](#any-testapi-key-resourcepath)
+  - [`POST /test/api-key-resource-policy`](#post-testapi-key-resource-policy)
 - [Request inspection](#request-inspection)
   - [`GET /test/requests`](#get-testrequests)
 - [Sanitization](#sanitization)
@@ -95,6 +97,8 @@ see [Sample resource](#sample-resource).
 | `POST` | `/test/refresh-tokens/rotate-policy` | Toggle refresh-token rotation |
 | `ANY` | `/test/resource/{path}` | Sample protected resource (bearer-required) |
 | `POST` | `/test/resource-policy` | Register scope policy for a resource path |
+| `ANY` | `/test/api-key-resource/{path}` | Sample API-key protected resource |
+| `POST` | `/test/api-key-resource-policy` | Register API-key policy for a resource path |
 | `GET` | `/test/requests` | Inspect recorded requests to recordable endpoints |
 
 All request and response bodies are JSON unless noted. Errors return
@@ -590,6 +594,74 @@ the token.
 **Errors**
 
 - `400` — missing or malformed path.
+
+### `ANY /test/api-key-resource/{path}`
+
+A sample API-key protected resource. Test-mode only. This is useful for
+exercising static API-key connectors without introducing a second
+upstream service.
+
+**Headers**
+
+- `Authorization: Bearer <key>` — default placement.
+- A custom header may be configured with
+  [`POST /test/api-key-resource-policy`](#post-testapi-key-resource-policy).
+
+**Behavior**
+
+If no policy has been registered for the exact path, the handler
+accepts `Authorization: Bearer demo-api-key`. A successful request
+returns:
+
+```json
+{
+  "path": "<request path>",
+  "auth": "api-key",
+  "placement": "bearer",
+  "headerName": ""
+}
+```
+
+**Errors**
+
+- `401 invalid_token` — missing or wrong API key.
+
+### `POST /test/api-key-resource-policy`
+
+Register the API key accepted for an API-key resource path. Test-mode
+only.
+
+**Request body**
+
+```json
+{
+  "path": "/test/api-key-resource/demo",
+  "key": "demo-api-key",
+  "placement": "bearer"
+}
+```
+
+Header placement:
+
+```json
+{
+  "path": "/test/api-key-resource/demo",
+  "key": "demo-api-key",
+  "placement": "header",
+  "header_name": "X-Demo-Api-Key",
+  "prefix": "Token "
+}
+```
+
+**Response**
+
+`204 No Content`.
+
+**Errors**
+
+- `400` — malformed JSON; missing `path` or `key`; unsupported
+  placement; header placement without `header_name`; path does not
+  start with `/test/api-key-resource/`.
 
 ## Request inspection
 

--- a/testmode/integration_test.go
+++ b/testmode/integration_test.go
@@ -1373,6 +1373,74 @@ func TestResourceServer(t *testing.T) {
 	})
 }
 
+func TestAPIKeySampleResource(t *testing.T) {
+	app := newTestApp(t, true)
+	srv := app.server
+
+	getResource := func(t *testing.T, path string, headers map[string]string) (int, []byte) {
+		t.Helper()
+		req, _ := http.NewRequest("GET", srv.URL+path, nil)
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("get api-key resource: %v", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return resp.StatusCode, body
+	}
+
+	t.Run("default bearer key returns 200 body", func(t *testing.T) {
+		status, body := getResource(t, "/test/api-key-resource/demo", map[string]string{
+			"Authorization": "Bearer demo-api-key",
+		})
+		if status != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", status, body)
+		}
+		var doc map[string]any
+		json.Unmarshal(body, &doc)
+		if doc["path"] != "/test/api-key-resource/demo" || doc["auth"] != "api-key" {
+			t.Fatalf("unexpected api-key resource body: %v", doc)
+		}
+	})
+
+	t.Run("bad bearer key returns 401", func(t *testing.T) {
+		status, body := getResource(t, "/test/api-key-resource/demo", map[string]string{
+			"Authorization": "Bearer wrong-key",
+		})
+		if status != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d body=%s", status, body)
+		}
+	})
+
+	t.Run("configured header placement returns 200", func(t *testing.T) {
+		buf, _ := json.Marshal(map[string]string{
+			"path":        "/test/api-key-resource/header-demo",
+			"key":         "header-demo-key",
+			"placement":   "header",
+			"header_name": "X-Demo-Api-Key",
+			"prefix":      "Token ",
+		})
+		resp, err := http.Post(srv.URL+"/test/api-key-resource-policy", "application/json", bytes.NewReader(buf))
+		if err != nil {
+			t.Fatalf("post api-key policy: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("expected policy 204, got %d", resp.StatusCode)
+		}
+
+		status, body := getResource(t, "/test/api-key-resource/header-demo", map[string]string{
+			"X-Demo-Api-Key": "Token header-demo-key",
+		})
+		if status != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", status, body)
+		}
+	})
+}
+
 func TestPKCE(t *testing.T) {
 	app := newTestApp(t, true)
 	srv := app.server

--- a/testmode/resource.go
+++ b/testmode/resource.go
@@ -17,8 +17,28 @@ type resourcePolicies struct {
 	rules map[string]string // path -> required scope (space-separated)
 }
 
+// apiKeyResourcePolicies holds test-mode API key requirements keyed by exact
+// path (e.g. "/test/api-key-resource/demo"). Tests register entries via
+// POST /test/api-key-resource-policy.
+type apiKeyResourcePolicies struct {
+	mu    sync.RWMutex
+	rules map[string]apiKeyResourcePolicy // path -> expected key + placement
+}
+
+type apiKeyResourcePolicy struct {
+	Path       string `json:"path"`
+	Key        string `json:"key"`
+	Placement  string `json:"placement,omitempty"`
+	HeaderName string `json:"header_name,omitempty"`
+	Prefix     string `json:"prefix,omitempty"`
+}
+
 func newResourcePolicies() *resourcePolicies {
 	return &resourcePolicies{rules: make(map[string]string)}
+}
+
+func newAPIKeyResourcePolicies() *apiKeyResourcePolicies {
+	return &apiKeyResourcePolicies{rules: make(map[string]apiKeyResourcePolicy)}
 }
 
 func (p *resourcePolicies) set(path, scope string) {
@@ -40,6 +60,25 @@ func (p *resourcePolicies) clear() {
 	p.rules = make(map[string]string)
 }
 
+func (p *apiKeyResourcePolicies) set(policy apiKeyResourcePolicy) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.rules[policy.Path] = policy
+}
+
+func (p *apiKeyResourcePolicies) get(path string) (apiKeyResourcePolicy, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	policy, ok := p.rules[path]
+	return policy, ok
+}
+
+func (p *apiKeyResourcePolicies) clear() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.rules = make(map[string]apiKeyResourcePolicy)
+}
+
 // resourceHandler implements ANY /test/resource/{path} in test mode.
 // Delegates to oauth.ServeSampleResource for bearer auth + body, with
 // the per-path scope policy registered via /test/resource-policy.
@@ -49,6 +88,53 @@ func (p *resourcePolicies) clear() {
 // here. The recorder captures the inbound request automatically.
 func (s *Service) resourceHandler(w http.ResponseWriter, r *http.Request) {
 	s.oauthService.ServeSampleResource(w, r, "test", s.resourcePolicies.get)
+}
+
+func (s *Service) apiKeyResourceHandler(w http.ResponseWriter, r *http.Request) {
+	policy, ok := s.apiKeyResourcePolicies.get(r.URL.Path)
+	if !ok {
+		policy = apiKeyResourcePolicy{
+			Path:       r.URL.Path,
+			Key:        "demo-api-key",
+			Placement:  "bearer",
+			HeaderName: "Authorization",
+			Prefix:     "Bearer ",
+		}
+	}
+
+	if !apiKeyResourceAuthorized(r, policy) {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="test-api-key", error="invalid_token"`)
+		response.Error(w, "invalid or missing API key", http.StatusUnauthorized)
+		return
+	}
+
+	response.WriteJSON(w, map[string]any{
+		"path":       r.URL.Path,
+		"auth":       "api-key",
+		"placement":  normalizedAPIKeyPlacement(policy),
+		"headerName": policy.HeaderName,
+	}, http.StatusOK)
+}
+
+func apiKeyResourceAuthorized(r *http.Request, policy apiKeyResourcePolicy) bool {
+	switch normalizedAPIKeyPlacement(policy) {
+	case "header":
+		headerName := policy.HeaderName
+		if headerName == "" {
+			headerName = "X-API-Key"
+		}
+		prefix := policy.Prefix
+		return r.Header.Get(headerName) == prefix+policy.Key
+	default:
+		return r.Header.Get("Authorization") == "Bearer "+policy.Key
+	}
+}
+
+func normalizedAPIKeyPlacement(policy apiKeyResourcePolicy) string {
+	if policy.Placement == "" {
+		return "bearer"
+	}
+	return strings.ToLower(policy.Placement)
 }
 
 // resourcePolicyRequest is the body of POST /test/resource-policy.
@@ -73,5 +159,41 @@ func (s *Service) resourcePolicyHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	s.resourcePolicies.set(req.Path, req.RequiredScope)
+	response.NoContent(w)
+}
+
+// apiKeyResourcePolicyHandler implements POST /test/api-key-resource-policy.
+func (s *Service) apiKeyResourcePolicyHandler(w http.ResponseWriter, r *http.Request) {
+	var req apiKeyResourcePolicy
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		response.Error(w, "invalid JSON body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Path == "" {
+		response.Error(w, "path is required", http.StatusBadRequest)
+		return
+	}
+	if !strings.HasPrefix(req.Path, "/test/api-key-resource/") {
+		response.Error(w, "path must start with /test/api-key-resource/", http.StatusBadRequest)
+		return
+	}
+	if req.Key == "" {
+		response.Error(w, "key is required", http.StatusBadRequest)
+		return
+	}
+	switch normalizedAPIKeyPlacement(req) {
+	case "bearer":
+		req.Placement = "bearer"
+	case "header":
+		req.Placement = "header"
+		if req.HeaderName == "" {
+			response.Error(w, "header_name is required for header placement", http.StatusBadRequest)
+			return
+		}
+	default:
+		response.Error(w, "placement must be bearer or header", http.StatusBadRequest)
+		return
+	}
+	s.apiKeyResourcePolicies.set(req)
 	response.NoContent(w)
 }

--- a/testmode/routes.go
+++ b/testmode/routes.go
@@ -13,6 +13,7 @@ func (s *Service) RegisterRoutes(router *mux.Router, prefix string) {
 	// /resource/* is a catch-all that matches any HTTP method, so it can't
 	// fit through routes.AddRoutes (which is method-specific).
 	subRouter.PathPrefix("/resource/").HandlerFunc(s.resourceHandler)
+	subRouter.PathPrefix("/api-key-resource/").HandlerFunc(s.apiKeyResourceHandler)
 }
 
 // GetRoutes returns the routes exposed by the test-mode control plane.
@@ -83,6 +84,12 @@ func (s *Service) GetRoutes() []routes.Route {
 			Method:      "POST",
 			Pattern:     "/resource-policy",
 			HandlerFunc: s.resourcePolicyHandler,
+		},
+		{
+			Name:        "test_api_key_resource_policy",
+			Method:      "POST",
+			Pattern:     "/api-key-resource-policy",
+			HandlerFunc: s.apiKeyResourcePolicyHandler,
 		},
 		{
 			Name:        "test_user_identity",

--- a/testmode/service.go
+++ b/testmode/service.go
@@ -8,23 +8,25 @@ import (
 
 // Service holds dependencies for the test-mode control plane.
 type Service struct {
-	cnf              *config.Config
-	db               *gorm.DB
-	oauthService     oauth.ServiceInterface
-	recorder         *Recorder
-	queue            *ScriptQueue
-	resourcePolicies *resourcePolicies
+	cnf                    *config.Config
+	db                     *gorm.DB
+	oauthService           oauth.ServiceInterface
+	recorder               *Recorder
+	queue                  *ScriptQueue
+	resourcePolicies       *resourcePolicies
+	apiKeyResourcePolicies *apiKeyResourcePolicies
 }
 
 // NewService constructs a test-mode service.
 func NewService(cnf *config.Config, db *gorm.DB, oauthService oauth.ServiceInterface) *Service {
 	return &Service{
-		cnf:              cnf,
-		db:               db,
-		oauthService:     oauthService,
-		recorder:         NewRecorder(0),
-		queue:            NewScriptQueue(),
-		resourcePolicies: newResourcePolicies(),
+		cnf:                    cnf,
+		db:                     db,
+		oauthService:           oauthService,
+		recorder:               NewRecorder(0),
+		queue:                  NewScriptQueue(),
+		resourcePolicies:       newResourcePolicies(),
+		apiKeyResourcePolicies: newAPIKeyResourcePolicies(),
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a test-mode /test/api-key-resource/* endpoint for static API-key demos and tests
- add /test/api-key-resource-policy for bearer/header key policies
- document the new endpoints and cover default bearer, bad key, and header placement behavior

## Tests
- go test ./testmode
- go test ./... (fails only in oauth package because local test env has no postgres host; integration and testmode passed)